### PR TITLE
rename slip's quantity arg to wad

### DIFF
--- a/src/vat.sol
+++ b/src/vat.sol
@@ -128,8 +128,8 @@ contract Vat {
     }
 
     // --- Fungibility ---
-    function slip(bytes32 ilk, bytes32 usr, int256 rad) public note auth {
-        gem[ilk][usr] = add(gem[ilk][usr], rad);
+    function slip(bytes32 ilk, bytes32 usr, int256 wad) public note auth {
+        gem[ilk][usr] = add(gem[ilk][usr], wad);
     }
     function flux(bytes32 ilk, bytes32 src, bytes32 dst, uint256 wad) public note {
         require(wish(src, msg.sender));


### PR DESCRIPTION
Rename a Vat.slip arg from `rad` to `wad` that should have been renamed in [an earlier commit](https://github.com/makerdao/dss/commit/285086d59e899fcdabb289d18660d654aad57e5f).