### PR TITLE
Remove EthJoin from dss; weth suffices

### DIFF
--- a/src/join.sol
+++ b/src/join.sol
@@ -43,8 +43,6 @@ contract VatLike {
       - `GemJoin`: For well behaved ERC20 tokens, with simple transfer
                    semantics.
 
-      - `ETHJoin`: For native Ether.
-
       - `DaiJoin`: For connecting internal Dai balances to an external
                    `DSToken` implementation.
 
@@ -78,25 +76,6 @@ contract GemJoin is DSNote {
         require(int(wad) >= 0);
         vat.slip(ilk, urn, -int(wad));
         require(gem.transfer(usr, wad));
-    }
-}
-
-contract ETHJoin is DSNote {
-    VatLike public vat;
-    bytes32 public ilk;
-    constructor(address vat_, bytes32 ilk_) public {
-        vat = VatLike(vat_);
-        ilk = ilk_;
-    }
-    function join(address urn) public payable note {
-        require(int(msg.value) >= 0);
-        vat.slip(ilk, urn, int(msg.value));
-    }
-    function exit(address payable usr, uint wad) public note {
-        address urn = msg.sender;
-        require(int(wad) >= 0);
-        vat.slip(ilk, urn, -int(wad));
-        usr.transfer(wad);
     }
 }
 

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -7,7 +7,7 @@ import {Vat} from '../vat.sol';
 import {Cat} from '../cat.sol';
 import {Vow} from '../vow.sol';
 import {Jug} from '../jug.sol';
-import {GemJoin, ETHJoin, DaiJoin} from '../join.sol';
+import {GemJoin, DaiJoin} from '../join.sol';
 
 import {Flipper} from './flip.t.sol';
 import {Flopper} from './flop.t.sol';
@@ -308,7 +308,6 @@ contract FrobTest is DSTest {
 
 contract JoinTest is DSTest {
     TestVat vat;
-    ETHJoin ethA;
     DaiJoin daiA;
     DSToken dai;
     address me;
@@ -317,26 +316,12 @@ contract JoinTest is DSTest {
         vat = new TestVat();
         vat.init("eth");
 
-        ethA = new ETHJoin(address(vat), "eth");
-        vat.rely(address(ethA));
-
         dai  = new DSToken("Dai");
         daiA = new DaiJoin(address(vat), address(dai));
         vat.rely(address(daiA));
         dai.setOwner(address(daiA));
 
         me = address(this);
-    }
-    function () external payable {}
-    function test_eth_join() public {
-        ethA.join.value(10 ether)(address(this));
-        assertEq(vat.gem("eth", me), 10 ether);
-    }
-    function test_eth_exit() public {
-        address payable urn = address(this);
-        ethA.join.value(50 ether)(urn);
-        ethA.exit(urn, 10 ether);
-        assertEq(vat.gem("eth", me), 40 ether);
     }
     function rad(uint wad) internal pure returns (uint) {
         return wad * 10 ** 27;
@@ -358,14 +343,6 @@ contract JoinTest is DSTest {
         daiA.join(urn, 30 ether);
         assertEq(dai.balanceOf(address(this)),     30 ether);
         assertEq(vat.dai(me),                  rad(70 ether));
-    }
-    function test_fallback_reverts() public {
-        (bool ok,) = address(ethA).call("invalid calldata");
-        assertTrue(!ok);
-    }
-    function test_nonzero_fallback_reverts() public {
-        (bool ok,) = address(ethA).call.value(10)("invalid calldata");
-        assertTrue(!ok);
     }
 }
 


### PR DESCRIPTION
With https://github.com/makerdao/dss-deploy/pull/14, `EthJoin` is no longer a part of MCD deployment