### PR TITLE
add DSNote to dai and end to be used with rely/deny auth

### DIFF
--- a/src/dai.sol
+++ b/src/dai.sol
@@ -15,11 +15,13 @@
 
 pragma solidity >=0.4.24;
 
-contract Dai {
+import "./lib.sol";
+
+contract Dai is DSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
-    function rely(address guy) public auth { wards[guy] = 1; }
-    function deny(address guy) public auth { wards[guy] = 0; }
+    function rely(address guy) public note auth { wards[guy] = 1; }
+    function deny(address guy) public note auth { wards[guy] = 0; }
     modifier auth { require(wards[msg.sender] == 1); _; }
 
     // --- ERC20 Data ---

--- a/src/end.sol
+++ b/src/end.sol
@@ -19,6 +19,8 @@
 pragma solidity >=0.5.0;
 pragma experimental ABIEncoderV2;
 
+import "./lib.sol";
+
 contract VatLike {
     struct Ilk {
         uint256 Art;
@@ -175,11 +177,11 @@ contract Spotty {
         - the number of gems is limited by how big your bag is
 */
 
-contract End {
+contract End is DSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
-    function rely(address guy) public auth { wards[guy] = 1; }
-    function deny(address guy) public auth { wards[guy] = 0; }
+    function rely(address guy) public note auth { wards[guy] = 1; }
+    function deny(address guy) public note auth { wards[guy] = 0; }
     modifier auth { require(wards[msg.sender] == 1); _; }
 
     // --- Data ---


### PR DESCRIPTION
Dai and End utilized the rely/deny auth methodology, but without `note` on the `rely`/`deny` functions.  Without these events, it becomes very difficult to track auth with these contracts and these contracts do not follow the patterns of other `dss` contracts. I added the `./lib.sol` and made both of these `DSNote` contracts.  This should is primarily necessary for tracking the authorization, so if there was a reason `note` was removed from these two contracts, feel free to let me know and ignore this PR.