### PR TITLE
add rho check to join

### DIFF
--- a/src/pot.sol
+++ b/src/pot.sol
@@ -123,7 +123,7 @@ contract Pot is DSNote {
 
     // --- Savings Rate Accumulation ---
     function drip() external note {
-        require(now >= rho);
+        require(now >= rho, "no-double-drip");
         uint chi_ = sub(rmul(rpow(dsr, now - rho, ONE), chi), chi);
         chi = add(chi, chi_);
         rho = now;
@@ -132,6 +132,7 @@ contract Pot is DSNote {
 
     // --- Savings Dai Management ---
     function join(uint wad) external note {
+        require(now == rho, "no-stale-chi");
         pie[msg.sender] = add(pie[msg.sender], wad);
         Pie             = add(Pie,             wad);
         vat.move(msg.sender, address(this), mul(chi, wad));

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -123,7 +123,7 @@ contract Pot is DSNote {
 
     // --- Savings Rate Accumulation ---
     function drip() external note {
-        require(now >= rho, "no-double-drip");
+        require(now >= rho);
         uint chi_ = sub(rmul(rpow(dsr, now - rho, ONE), chi), chi);
         chi = add(chi, chi_);
         rho = now;
@@ -132,7 +132,7 @@ contract Pot is DSNote {
 
     // --- Savings Dai Management ---
     function join(uint wad) external note {
-        require(now == rho, "no-stale-chi");
+        require(now == rho);
         pie[msg.sender] = add(pie[msg.sender], wad);
         Pie             = add(Pie,             wad);
         vat.move(msg.sender, address(this), mul(chi, wad));

--- a/src/test/pot.t.sol
+++ b/src/test/pot.t.sol
@@ -76,6 +76,20 @@ contract DSRTest is DSTest {
         assertEq(pot.Pie(),          100   ether);
         assertEq(pot.chi() / 10 ** 9, 1.155 ether);
     }
+    function test_drip_multi_inBlock() public {
+        pot.drip();
+        uint rho = pot.rho();
+        assertEq(rho, now);
+        hevm.warp(now + 1 days);
+        rho = pot.rho();
+        assertEq(rho, now - 1 days);
+        pot.drip();
+        rho = pot.rho();
+        assertEq(rho, now);
+        pot.drip();
+        rho = pot.rho();
+        assertEq(rho, now);
+    }
     function test_save_multi() public {
         pot.join(100 ether);
         pot.file("dsr", uint(1000000564701133626865910626));  // 5% / day

--- a/src/test/pot.t.sol
+++ b/src/test/pot.t.sol
@@ -92,4 +92,22 @@ contract DSRTest is DSTest {
         assertEq(wad(vat.dai(self)), 110.25 ether);
         assertEq(pot.Pie(),            0.00 ether);
     }
+    function test_fresh_chi() public {
+        uint rho = pot.rho();
+        assertEq(rho, now);
+        hevm.warp(now + 1 days);
+        assertEq(rho, now - 1 days);
+        pot.drip();
+        pot.join(100 ether);
+        assertEq(pot.pie(self), 100 ether);
+        pot.exit(100 ether);
+        // if we exit in the same transaction we should not earn DSR
+        assertEq(wad(vat.dai(self)), 100 ether);
+    }
+    function testFail_stale_chi() public {
+        pot.file("dsr", uint(1000000564701133626865910626));  // 5% / day
+        pot.drip();
+        hevm.warp(now + 1 days);
+        pot.join(100 ether);
+    }
 }


### PR DESCRIPTION
Protecting against `Pot.join` + `Pot.exit` single transaction profitability. 