### PR TITLE
Flop varying sized mkr lots

### DIFF
--- a/src/flop.sol
+++ b/src/flop.sol
@@ -60,6 +60,7 @@ contract Flopper is DSNote {
 
     uint256  constant ONE = 1.00E27;
     uint256  public   beg = 1.05E27;  // 5% minimum bid increase
+    uint256  public   leg = 1.50E27;  // 50% lot increase for tick
     uint48   public   ttl = 3 hours;  // 3 hours bid lifetime
     uint48   public   tau = 2 days;   // 2 days total auction length
     uint256  public kicks = 0;
@@ -92,6 +93,7 @@ contract Flopper is DSNote {
     // --- Admin ---
     function file(bytes32 what, uint data) external note auth {
         if (what == "beg") beg = data;
+        else if (what == "leg") leg = data;
         else if (what == "ttl") ttl = uint48(data);
         else if (what == "tau") tau = uint48(data);
         else revert();
@@ -113,7 +115,7 @@ contract Flopper is DSNote {
     function tick(uint id) external note {
         require(bids[id].end < now);
         require(bids[id].tic == 0);
-        bids[id].lot = mul(beg, bids[id].lot) / ONE;
+        bids[id].lot = mul(leg, bids[id].lot) / ONE;
         bids[id].end = add(uint48(now), tau);
     }
     function dent(uint id, uint lot, uint bid) external note {

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -113,6 +113,7 @@ contract Flopper is DSNote {
     function tick(uint id) external note {
         require(bids[id].end < now);
         require(bids[id].tic == 0);
+        bids[id].lot = mul(beg, bids[id].lot) / ONE;
         bids[id].end = add(uint48(now), tau);
     }
     function dent(uint id, uint lot, uint bid) external note {

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -60,7 +60,7 @@ contract Flopper is DSNote {
 
     uint256  constant ONE = 1.00E27;
     uint256  public   beg = 1.05E27;  // 5% minimum bid increase
-    uint256  public   leg = 1.50E27;  // 50% lot increase for tick
+    uint256  public   pad = 1.50E27;  // 50% lot increase for tick
     uint48   public   ttl = 3 hours;  // 3 hours bid lifetime
     uint48   public   tau = 2 days;   // 2 days total auction length
     uint256  public kicks = 0;
@@ -93,7 +93,7 @@ contract Flopper is DSNote {
     // --- Admin ---
     function file(bytes32 what, uint data) external note auth {
         if (what == "beg") beg = data;
-        else if (what == "leg") leg = data;
+        else if (what == "pad") pad = data;
         else if (what == "ttl") ttl = uint48(data);
         else if (what == "tau") tau = uint48(data);
         else revert();
@@ -115,7 +115,7 @@ contract Flopper is DSNote {
     function tick(uint id) external note {
         require(bids[id].end < now);
         require(bids[id].tic == 0);
-        bids[id].lot = mul(leg, bids[id].lot) / ONE;
+        bids[id].lot = mul(pad, bids[id].lot) / ONE;
         bids[id].end = add(uint48(now), tau);
     }
     function dent(uint id, uint lot, uint bid) external note {

--- a/src/test/flop.t.sol
+++ b/src/test/flop.t.sol
@@ -147,6 +147,7 @@ contract FlopTest is DSTest {
         assertTrue( Guy(ali).try_tick(id));
         // check biddable
         (, uint _lot,,,) = flop.bids(id);
+        // tick should increase the lot by beg (5%) and restart the auction
         assertEq(_lot, 210 ether);
         assertTrue( Guy(ali).try_dent(id, 100 ether, 10 ether));
     }

--- a/src/test/flop.t.sol
+++ b/src/test/flop.t.sol
@@ -147,8 +147,8 @@ contract FlopTest is DSTest {
         assertTrue( Guy(ali).try_tick(id));
         // check biddable
         (, uint _lot,,,) = flop.bids(id);
-        // tick should increase the lot by beg (5%) and restart the auction
-        assertEq(_lot, 210 ether);
+        // tick should increase the lot by beg (50%) and restart the auction
+        assertEq(_lot, 300 ether);
         assertTrue( Guy(ali).try_dent(id, 100 ether, 10 ether));
     }
     function test_no_deal_after_end() public {

--- a/src/test/flop.t.sol
+++ b/src/test/flop.t.sol
@@ -147,7 +147,7 @@ contract FlopTest is DSTest {
         assertTrue( Guy(ali).try_tick(id));
         // check biddable
         (, uint _lot,,,) = flop.bids(id);
-        // tick should increase the lot by beg (50%) and restart the auction
+        // tick should increase the lot by pad (50%) and restart the auction
         assertEq(_lot, 300 ether);
         assertTrue( Guy(ali).try_dent(id, 100 ether, 10 ether));
     }

--- a/src/test/flop.t.sol
+++ b/src/test/flop.t.sol
@@ -95,7 +95,7 @@ contract FlopTest is DSTest {
     function test_kick() public {
         assertEq(vat.dai(address(this)), 600 ether);
         assertEq(gem.balanceOf(address(this)),   0 ether);
-        flop.kick({ lot: uint(-1)   // or whatever high starting value
+        flop.kick({ lot: 200 ether   // or whatever high starting value
                   , gal: gal
                   , bid: 0
                   });
@@ -104,7 +104,7 @@ contract FlopTest is DSTest {
         assertEq(gem.balanceOf(address(this)),   0 ether);
     }
     function test_dent() public {
-        uint id = flop.kick({ lot: uint(-1)   // or whatever high starting value
+        uint id = flop.kick({ lot: 200 ether   // or whatever high starting value
                             , gal: gal
                             , bid: 10 ether
                             });
@@ -134,7 +134,7 @@ contract FlopTest is DSTest {
     }
     function test_tick() public {
         // start an auction
-        uint id = flop.kick({ lot: uint(-1)   // or whatever high starting value
+        uint id = flop.kick({ lot: 200 ether   // or whatever high starting value
                             , gal: gal
                             , bid: 10 ether
                             });
@@ -146,12 +146,14 @@ contract FlopTest is DSTest {
         assertTrue(!Guy(ali).try_dent(id, 100 ether, 10 ether));
         assertTrue( Guy(ali).try_tick(id));
         // check biddable
+        (, uint _lot,,,) = flop.bids(id);
+        assertEq(_lot, 210 ether);
         assertTrue( Guy(ali).try_dent(id, 100 ether, 10 ether));
     }
     function test_no_deal_after_end() public {
         // if there are no bids and the auction ends, then it should not
         // be refundable to the creator. Rather, it ticks indefinitely.
-        uint id = flop.kick({ lot: uint(-1)   // or whatever high starting value
+        uint id = flop.kick({ lot: 200 ether   // or whatever high starting value
                             , gal: gal
                             , bid: 10 ether
                             });

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -596,7 +596,7 @@ contract BiteTest is DSTest {
         assertEq(vow.Ash(), rad(  0 ether));
 
         vow.file("sump", rad(10 ether));
-        vow.file("pump", 2000 ether);
+        vow.file("dump", 2000 ether);
         uint f1 = vow.flop();
         assertEq(vow.Woe(),  rad(90 ether));
         assertEq(vow.Joy(),  rad( 0 ether));

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -596,6 +596,7 @@ contract BiteTest is DSTest {
         assertEq(vow.Ash(), rad(  0 ether));
 
         vow.file("sump", rad(10 ether));
+        vow.file("pump", 2000 ether);
         uint f1 = vow.flop();
         assertEq(vow.Woe(),  rad(90 ether));
         assertEq(vow.Joy(),  rad( 0 ether));

--- a/src/test/vow.t.sol
+++ b/src/test/vow.t.sol
@@ -42,6 +42,7 @@ contract VowTest is DSTest {
 
         vow.file("bump", rad(100 ether));
         vow.file("sump", rad(100 ether));
+        vow.file("pump", 200 ether);
 
         vat.hope(address(flop));
     }

--- a/src/test/vow.t.sol
+++ b/src/test/vow.t.sol
@@ -42,7 +42,7 @@ contract VowTest is DSTest {
 
         vow.file("bump", rad(100 ether));
         vow.file("sump", rad(100 ether));
-        vow.file("pump", 200 ether);
+        vow.file("dump", 200 ether);
 
         vat.hope(address(flop));
     }

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -89,7 +89,7 @@ contract Vow is DSNote {
         if (what == "wait") wait = data;
         else if (what == "bump") bump = data;
         else if (what == "sump") sump = data;
-        else if (what == "dump") pump = data;
+        else if (what == "dump") dump = data;
         else if (what == "hump") hump = data;
         else revert();
     }

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -55,7 +55,9 @@ contract Vow is DSNote {
     uint256 public Ash;   // on-auction debt      [rad]
 
     uint256 public wait;  // flop delay           [rad]
-    uint256 public sump;  // flop fixed lot size  [rad]
+    uint256 public pump;  // flop fixed lot size  [rad]
+    uint256 public sump;  // flop fixed bid size  [rad]
+
     uint256 public bump;  // flap fixed lot size  [rad]
     uint256 public hump;  // surplus buffer       [rad]
 
@@ -87,6 +89,7 @@ contract Vow is DSNote {
         if (what == "wait") wait = data;
         else if (what == "bump") bump = data;
         else if (what == "sump") sump = data;
+        else if (what == "pump") pump = data;
         else if (what == "hump") hump = data;
         else revert();
     }
@@ -121,7 +124,7 @@ contract Vow is DSNote {
         require(sump <= sub(sub(vat.sin(address(this)), Sin), Ash));
         require(vat.dai(address(this)) == 0);
         Ash = add(Ash, sump);
-        id = flopper.kick(address(this), uint(-1), sump);
+        id = flopper.kick(address(this), pump, sump);
     }
     // Surplus auction
     function flap() external note returns (uint id) {

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -54,11 +54,11 @@ contract Vow is DSNote {
     uint256 public Sin;   // queued debt          [rad]
     uint256 public Ash;   // on-auction debt      [rad]
 
-    uint256 public wait;  // flop delay           [rad]
-    uint256 public pump;  // flop fixed lot size  [rad]
-    uint256 public sump;  // flop fixed bid size  [rad]
+    uint256 public wait;  // flop delay            [rad]
+    uint256 public dump;  // flop fixed lot size    [rad]
+    uint256 public sump;  // flop fixed bid size    [rad]
 
-    uint256 public bump;  // flap fixed lot size  [rad]
+    uint256 public bump;  // flap fixed lot size    [rad]
     uint256 public hump;  // surplus buffer       [rad]
 
     uint256 public live;
@@ -89,7 +89,7 @@ contract Vow is DSNote {
         if (what == "wait") wait = data;
         else if (what == "bump") bump = data;
         else if (what == "sump") sump = data;
-        else if (what == "pump") pump = data;
+        else if (what == "dump") pump = data;
         else if (what == "hump") hump = data;
         else revert();
     }
@@ -124,7 +124,7 @@ contract Vow is DSNote {
         require(sump <= sub(sub(vat.sin(address(this)), Sin), Ash));
         require(vat.dai(address(this)) == 0);
         Ash = add(Ash, sump);
-        id = flopper.kick(address(this), pump, sump);
+        id = flopper.kick(address(this), dump, sump);
     }
     // Surplus auction
     function flap() external note returns (uint id) {


### PR DESCRIPTION
Currently Vow uses `uint(-1)` as the starting point for Flop auctions.  This is:
1) a huge but arbitrary number
2) will cause the auction to fail if there are no bids as it is not possible to mint uint(-1) new MKR because `totalSupply` would overflow
3) it opens the possibility of low bidder participation minting a huge amount of MKR.

This introduces `Vow.dump` which would be the governance-controlled variable for how much `lot` (i.e. MKR gems) the Flop auction should start with. The `dump` replaces `uint(-1)` as the ceiling from which to start the `Flop`/`dent` auctions. If bidders do not feel this amount is worth the asking `bid` and the auction expires with 0 bids, then `tick` will increase the `lot` by `beg` and restart the auction.

Benefits of this approach:
- Since it is governance set, it is no longer arbitrary
- As long as Governance acts responsibly:
 - this number should not be so large to cause an overflow
 - this number should not represent a "thread" to MKR governance in the case of low bidder participation

However, this approach:
- requires an additional governance variable, increasing complexity
- needs further discussion around the economic/game theory consequences as it possibly introduces an incentive for bidders to wait until `tick` can be called.

(updated to change `pump` to `dump`)