### PR TITLE
add end to the pot to prevent drips after global settlement starts

### DIFF
--- a/src/end.sol
+++ b/src/end.sol
@@ -53,6 +53,9 @@ contract CatLike {
     function ilks(bytes32) external returns (Ilk memory);
     function cage() external;
 }
+contract PotLike {
+    function cage() external;
+}
 contract VowLike {
     function heal(uint256 rad) external;
     function cage() external;
@@ -94,6 +97,7 @@ contract Spotty {
         - freezes user entrypoints
         - cancels flop/flap auctions
         - starts cooldown period
+        - stops pot drips
 
     2. `cage(ilk)`:
        - set the cage price for each `ilk`, reading off the price feed
@@ -194,6 +198,7 @@ contract End is DSNote {
     VatLike  public vat;
     CatLike  public cat;
     VowLike  public vow;
+    PotLike  public pot;
     Spotty   public spot;
 
     uint256  public live;  // cage flag
@@ -243,6 +248,7 @@ contract End is DSNote {
         if (what == "vat")  vat = VatLike(data);
         if (what == "cat")  cat = CatLike(data);
         if (what == "vow")  vow = VowLike(data);
+        if (what == "pot")  pot = PotLike(data);
         if (what == "spot") spot = Spotty(data);
     }
     function file(bytes32 what, uint256 data) external note auth {
@@ -257,6 +263,7 @@ contract End is DSNote {
         vat.cage();
         cat.cage();
         vow.cage();
+        pot.cage();
     }
 
     function cage(bytes32 ilk) external note {

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -117,6 +117,7 @@ contract Pot is DSNote {
 
     // --- Administration ---
     function file(bytes32 what, uint256 data) external note auth {
+        require(live == 1);
         if (what == "dsr") dsr = data;
     }
 
@@ -126,11 +127,11 @@ contract Pot is DSNote {
 
     function cage() external note auth {
         live = 0;
+        dsr = ONE;
     }
 
     // --- Savings Rate Accumulation ---
     function drip() external note {
-        require(live == 1);
         require(now >= rho);
         uint chi_ = sub(rmul(rpow(dsr, now - rho, ONE), chi), chi);
         chi = add(chi, chi_);

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -61,6 +61,8 @@ contract Pot is DSNote {
     address public vow;  // debt engine
     uint256 public rho;  // time of last drip
 
+    uint256 public live;  // Access Flag
+
     // --- Init ---
     constructor(address vat_) public {
         wards[msg.sender] = 1;
@@ -68,6 +70,7 @@ contract Pot is DSNote {
         dsr = ONE;
         chi = ONE;
         rho = now;
+        live = 1;
     }
 
     // --- Math ---
@@ -121,8 +124,13 @@ contract Pot is DSNote {
         if (what == "vow") vow = addr;
     }
 
+    function cage() external note auth {
+        live = 0;
+    }
+
     // --- Savings Rate Accumulation ---
     function drip() external note {
+        require(live == 1);
         require(now >= rho);
         uint chi_ = sub(rmul(rpow(dsr, now - rho, ONE), chi), chi);
         chi = add(chi, chi_);

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -145,6 +145,12 @@ contract EndTest is DSTest {
         return ilks[ilk].gem.balanceOf(usr);
     }
 
+    function try_pot_file(bytes32 what, uint data) public returns(bool ok) {
+        string memory sig = "file(bytes32, uint)";
+        address self = address(this);
+        (ok,) = address(pot).call(abi.encodeWithSignature(sig, what, data));
+    }
+
     function init_collateral(bytes32 name) internal returns (Ilk memory) {
         DSToken coin = new DSToken(name);
         coin.mint(20 ether);
@@ -239,13 +245,14 @@ contract EndTest is DSTest {
         assertEq(vow.flapper().live(), 0);
     }
 
-    function testFail_cage_drip() public {
+    function test_cage_pot_drip() public {
         assertEq(pot.live(), 1);
         pot.drip();
         end.cage();
 
         assertEq(pot.live(), 0);
-        pot.drip();
+        assertEq(pot.dsr(), 10 ** 27);
+        assertTrue(!try_pot_file("dsr", 10 ** 27 + 1));
     }
 
     // -- Scenario where there is one over-collateralised CDP

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -25,6 +25,7 @@ import "ds-value/value.sol";
 import {Vat}  from '../vat.sol';
 import {Cat}  from '../cat.sol';
 import {Vow}  from '../vow.sol';
+import {Pot}  from '../pot.sol';
 import {Flipper} from '../flip.sol';
 import {Flapper} from '../flap.sol';
 import {Flopper} from '../flop.sol';
@@ -87,6 +88,7 @@ contract EndTest is DSTest {
     Vat   vat;
     End   end;
     Vow   vow;
+    Pot   pot;
     Cat   cat;
 
     TestSpot spot;
@@ -192,6 +194,10 @@ contract EndTest is DSTest {
 
         vow = new Vow(address(vat), address(flap), address(flop));
 
+        pot = new Pot(address(vat));
+        vat.rely(address(pot));
+        pot.file("vow", address(vow));
+
         cat = new Cat(address(vat));
         cat.file("vow", address(vow));
         vat.rely(address(cat));
@@ -204,10 +210,12 @@ contract EndTest is DSTest {
         end.file("vat", address(vat));
         end.file("cat", address(cat));
         end.file("vow", address(vow));
+        end.file("pot", address(pot));
         end.file("spot", address(spot));
         end.file("wait", 1 hours);
         vat.rely(address(end));
         vow.rely(address(end));
+        pot.rely(address(end));
         cat.rely(address(end));
         flap.rely(address(vow));
         flop.rely(address(vow));
@@ -218,6 +226,7 @@ contract EndTest is DSTest {
         assertEq(vat.live(), 1);
         assertEq(cat.live(), 1);
         assertEq(vow.live(), 1);
+        assertEq(pot.live(), 1);
         assertEq(vow.flopper().live(), 1);
         assertEq(vow.flapper().live(), 1);
         end.cage();
@@ -225,8 +234,18 @@ contract EndTest is DSTest {
         assertEq(vat.live(), 0);
         assertEq(cat.live(), 0);
         assertEq(vow.live(), 0);
+        assertEq(pot.live(), 0);
         assertEq(vow.flopper().live(), 0);
         assertEq(vow.flapper().live(), 0);
+    }
+
+    function testFail_cage_drip() public {
+        assertEq(pot.live(), 1);
+        pot.drip();
+        end.cage();
+
+        assertEq(pot.live(), 0);
+        pot.drip();
     }
 
     // -- Scenario where there is one over-collateralised CDP

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -147,7 +147,6 @@ contract EndTest is DSTest {
 
     function try_pot_file(bytes32 what, uint data) public returns(bool ok) {
         string memory sig = "file(bytes32, uint)";
-        address self = address(this);
         (ok,) = address(pot).call(abi.encodeWithSignature(sig, what, data));
     }
 


### PR DESCRIPTION
Add Cage to the Pot so that when we start the `End` `Pot.drip` will no longer accumulate `DAI`