### PR TITLE
correct inconsistent time type in vow

### DIFF
--- a/src/test/vow.t.sol
+++ b/src/test/vow.t.sol
@@ -104,9 +104,9 @@ contract VowTest is DSTest {
     }
 
     function test_flog_wait() public {
-        assertEq(vow.wait(), 0);
+        assertEq(uint(vow.wait()), 0);
         vow.file('wait', uint(100 seconds));
-        assertEq(vow.wait(), 100 seconds);
+        assertEq(uint(vow.wait()), 100 seconds);
 
         uint tic = now;
         vow.fess(100 ether);

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -97,7 +97,7 @@ contract Vow is DSNote {
     }
     // Pop from debt-queue
     function flog(uint era) external note {
-        require(add(era, wait) <= now);
+        require(add(era, uint256(wait)) <= now);
         Sin = sub(Sin, sin[era]);
         sin[era] = 0;
     }

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -51,13 +51,13 @@ contract Vow is DSNote {
     Flopper public flopper;
 
     mapping (uint256 => uint256) public sin; // debt queue
-    uint256 public Sin;   // queued debt          [rad]
-    uint256 public Ash;   // on-auction debt      [rad]
+    uint256 public Sin;    // queued debt         [rad]
+    uint256 public Ash;    // on-auction debt     [rad]
 
-    uint256 public wait;  // flop delay           [rad]
-    uint256 public sump;  // flop fixed lot size  [rad]
-    uint256 public bump;  // flap fixed lot size  [rad]
-    uint256 public hump;  // surplus buffer       [rad]
+    uint48  public wait;   // flop delay           [rad]
+    uint256 public sump;   // flop fixed lot size   [rad]
+    uint256 public bump;   // flap fixed lot size   [rad]
+    uint256 public hump;   // surplus buffer      [rad]
 
     uint256 public live;
 
@@ -84,7 +84,7 @@ contract Vow is DSNote {
 
     // --- Administration ---
     function file(bytes32 what, uint data) external note auth {
-        if (what == "wait") wait = data;
+        if (what == "wait") wait = uint48(data);
         if (what == "bump") bump = data;
         if (what == "sump") sump = data;
         if (what == "hump") hump = data;


### PR DESCRIPTION
Makes `wait` a `uint48` which matches the type used for other time variables.