### PR TITLE
Remove unneeded `VatLike.flux`

### DIFF
--- a/src/join.sol
+++ b/src/join.sol
@@ -32,7 +32,6 @@ contract DSTokenLike {
 contract VatLike {
     function slip(bytes32,address,int) external;
     function move(address,address,uint) external;
-    function flux(bytes32,address,address,uint) external;
 }
 
 /*


### PR DESCRIPTION
the `flux` interface was in the `VatLike` contract but was not used in any of the Join contracts