### PR TITLE
update cage(ilk) to account for the dai par

### DIFF
--- a/src/end.sol
+++ b/src/end.sol
@@ -84,6 +84,7 @@ contract Spotty {
         PipLike pip;
         uint256 mat;
     }
+    function poke(bytes32) external;
     function ilks(bytes32) external view returns (Ilk memory);
 }
 
@@ -270,8 +271,9 @@ contract End is DSNote {
         require(live == 0);
         require(tag[ilk] == 0);
         Art[ilk] = vat.ilks(ilk).Art;
-        // pip returns a wad, invert it and convert to ray
-        tag[ilk] = rdiv(WAD, uint(spot.ilks(ilk).pip.read()));
+        // spot and mat are both RAY, so multiple then invert it
+        spot.poke(ilk);
+        tag[ilk] = rdiv(RAY, rmul(vat.ilks(ilk).spot, spot.ilks(ilk).mat));
     }
 
     function skip(bytes32 ilk, uint256 id) external note {

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -37,26 +37,6 @@ contract Hevm {
     function warp(uint256) public;
 }
 
-// contract TestSpot {
-//     struct Ilk {
-//         address pip;
-//         uint256 mat;
-//     }
-//     mapping (bytes32 => Ilk) public ilks;
-
-//     function file(bytes32 ilk, address pip_) public {
-//         ilks[ilk].pip = pip_;
-//     }
-//     function poke(bytes32 ilk) external {
-//         (bytes32 val, bool zzz) = ilks[ilk].pip.peek();
-//         if (zzz) {
-//             uint256 spot = rdiv(rdiv(mul(uint(val), 10 ** 9), par), ilks[ilk].mat);
-//             vat.file(ilk, "spot", spot);
-//             emit Poke(ilk, val, spot);
-//         }
-//     }
-// }
-
 contract Usr {
     Vat public vat;
     End public end;

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -31,22 +31,31 @@ import {Flapper} from '../flap.sol';
 import {Flopper} from '../flop.sol';
 import {GemJoin} from '../join.sol';
 import {End}  from '../end.sol';
+import {Spotter} from '../spot.sol';
 
 contract Hevm {
     function warp(uint256) public;
 }
 
-contract TestSpot {
-    struct Ilk {
-        address pip;
-        uint256 mat;
-    }
-    mapping (bytes32 => Ilk) public ilks;
+// contract TestSpot {
+//     struct Ilk {
+//         address pip;
+//         uint256 mat;
+//     }
+//     mapping (bytes32 => Ilk) public ilks;
 
-    function file(bytes32 ilk, address pip_) public {
-        ilks[ilk].pip = pip_;
-    }
-}
+//     function file(bytes32 ilk, address pip_) public {
+//         ilks[ilk].pip = pip_;
+//     }
+//     function poke(bytes32 ilk) external {
+//         (bytes32 val, bool zzz) = ilks[ilk].pip.peek();
+//         if (zzz) {
+//             uint256 spot = rdiv(rdiv(mul(uint(val), 10 ** 9), par), ilks[ilk].mat);
+//             vat.file(ilk, "spot", spot);
+//             emit Poke(ilk, val, spot);
+//         }
+//     }
+// }
 
 contract Usr {
     Vat public vat;
@@ -91,7 +100,7 @@ contract EndTest is DSTest {
     Pot   pot;
     Cat   cat;
 
-    TestSpot spot;
+    Spotter spot;
 
     struct Ilk {
         DSValue pip;
@@ -156,6 +165,7 @@ contract EndTest is DSTest {
 
         DSValue pip = new DSValue();
         spot.file(name, address(pip));
+        spot.file(name, "mat", RAY);
         // initial collateral price of 5
         pip.poke(bytes32(5 * WAD));
 
@@ -208,8 +218,9 @@ contract EndTest is DSTest {
         vat.rely(address(cat));
         vow.rely(address(cat));
 
-        spot = new TestSpot();
+        spot = new Spotter(address(vat));
         vat.file("Line",         rad(1000 ether));
+        vat.rely(address(spot));
 
         end = new End();
         end.file("vat", address(vat));


### PR DESCRIPTION
Currently, the `Spot.par` or `ref per dai` is not accounted for during the `End`. This updates `cage(ilk)` to :
1 - Call `spot.poke(ilk)` to get the updated price in the `vat`
2 - Retrieves that `spot` price and the `spot.ilks(ilk).mat`
3 - multiplies the `spot` by the `mat` to calculate the ilk's tag with the `par` accounted for.

thank you to @gbalabasquer for suggesting this approach as a way of pulling in the `par`. 

As he points out we should evaluate if this is the best approach specifically in relation to its impact on FV for the `End`.