### PR TITLE
more gas efficient implementation of pot.drip

### DIFF
--- a/src/pot.sol
+++ b/src/pot.sol
@@ -135,8 +135,9 @@ contract Pot is DSNote {
     // --- Savings Rate Accumulation ---
     function drip() external note {
         require(now >= rho);
-        uint chi_ = sub(rmul(rpow(dsr, now - rho, ONE), chi), chi);
-        chi = add(chi, chi_);
+        uint latest = rmul(rpow(dsr, now - rho, ONE), chi);
+        uint chi_ = sub(latest, chi);
+        chi = latest;
         rho = now;
         vat.suck(address(vow), address(this), mul(Pie, chi_));
     }

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -135,9 +135,9 @@ contract Pot is DSNote {
     // --- Savings Rate Accumulation ---
     function drip() external note {
         require(now >= rho);
-        uint latest = rmul(rpow(dsr, now - rho, ONE), chi);
-        uint chi_ = sub(latest, chi);
-        chi = latest;
+        uint tmp = rmul(rpow(dsr, now - rho, ONE), chi);
+        uint chi_ = sub(tmp, chi);
+        chi = tmp;
         rho = now;
         vat.suck(address(vow), address(this), mul(Pie, chi_));
     }


### PR DESCRIPTION
hey,

I noticed in the `pot.drip` method the addition `chi = add(chi, chi_);` is more expensive than just to store the latest chi (calculated already in the previous line).

Improvement is around `~600 gas` per method call.

Since the method should be called very often. I think it makes sense to change it.

**Current Gas**
```
Running 7 tests for src/test/pot.t.sol:DSRTest
[PASS] testFail_stale_chi() (gas: 145165)
[PASS] test_drip_multi() (gas: 549591)
[PASS] test_drip_multi_inBlock() (gas: 375922)
[PASS] test_fresh_chi() (gas: 457704)
[PASS] test_save_0d() (gas: 454693)
[PASS] test_save_1d() (gas: 522272)
[PASS] test_save_multi() (gas: 761726)
```

**Improvement Gas**
```
Running 7 tests for src/test/pot.t.sol:DSRTest
[PASS] testFail_stale_chi() (gas: 144631)
[PASS] test_drip_multi() (gas: 548523)
[PASS] test_drip_multi_inBlock() (gas: 374320)
[PASS] test_fresh_chi() (gas: 457170)
[PASS] test_save_0d() (gas: 454159)
[PASS] test_save_1d() (gas: 521738)
[PASS] test_save_multi() (gas: 760658)
```


