### PR TITLE
flap/flip/flop.sol: beg and pad are wad now

### DIFF
--- a/src/flap.sol
+++ b/src/flap.sol
@@ -58,8 +58,8 @@ contract Flapper is DSNote {
     VatLike  public   vat;
     GemLike  public   gem;
 
-    uint256  constant ONE = 1.00E27;
-    uint256  public   beg = 1.05E27;  // 5% minimum bid increase
+    uint256  constant ONE = 1.00E18;
+    uint256  public   beg = 1.05E18;  // 5% minimum bid increase
     uint48   public   ttl = 3 hours;  // 3 hours bid duration
     uint48   public   tau = 2 days;   // 2 days total auction length
     uint256  public kicks = 0;

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -62,8 +62,8 @@ contract Flipper is DSNote {
     VatLike public   vat;
     bytes32 public   ilk;
 
-    uint256 constant ONE = 1.00E27;
-    uint256 public   beg = 1.05E27;  // 5% minimum bid increase
+    uint256 constant ONE = 1.00E18;
+    uint256 public   beg = 1.05E18;  // 5% minimum bid increase
     uint48  public   ttl = 3 hours;  // 3 hours bid duration
     uint48  public   tau = 2 days;   // 2 days total auction length
     uint256 public kicks = 0;

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -126,7 +126,7 @@ contract Flopper is DSNote {
 
         require(bid == bids[id].bid);
         require(lot <  bids[id].lot);
-        require(mul(beg, lot) / ONE <= bids[id].lot);  // div as lot can be huge
+        require(mul(beg, lot) <= mul(bids[id].lot, ONE));
 
         vat.move(msg.sender, bids[id].guy, bid);
 

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -58,9 +58,9 @@ contract Flopper is DSNote {
     VatLike  public   vat;
     GemLike  public   gem;
 
-    uint256  constant ONE = 1.00E27;
-    uint256  public   beg = 1.05E27;  // 5% minimum bid increase
-    uint256  public   pad = 1.50E27;  // 50% lot increase for tick
+    uint256  constant ONE = 1.00E18;
+    uint256  public   beg = 1.05E18;  // 5% minimum bid increase
+    uint256  public   pad = 1.50E18;  // 50% lot increase for tick
     uint48   public   ttl = 3 hours;  // 3 hours bid lifetime
     uint48   public   tau = 2 days;   // 2 days total auction length
     uint256  public kicks = 0;


### PR DESCRIPTION
I was also thinking on change this line in `flop.sol`:

```
require(mul(beg, lot) / ONE <= bids[id].lot);  // div as lot can be huge
```
to:
```
require(mul(beg, lot) <= mul(bids[id].lot, ONE));
```

As now the initial `bids[id].lot` is more controlled and `ONE` is smaller. But let me know what you think about it.