### PR TITLE
add auth to Flip.kick

### DIFF
--- a/src/flip.sol
+++ b/src/flip.sol
@@ -102,7 +102,7 @@ contract Flipper is DSNote {
 
     // --- Auction ---
     function kick(address usr, address gal, uint tab, uint lot, uint bid)
-        public returns (uint id)
+        public auth returns (uint id)
     {
         require(kicks < uint(-1));
         id = ++kicks;

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -167,6 +167,7 @@ contract EndTest is DSTest {
         Flipper flip = new Flipper(address(vat), name);
         vat.hope(address(flip));
         flip.rely(address(end));
+        flip.rely(address(cat));
         cat.file(name, "flip", address(flip));
         cat.file(name, "chop", ray(1 ether));
         cat.file(name, "lump", rad(15 ether));

--- a/src/test/flip.t.sol
+++ b/src/test/flip.t.sol
@@ -99,6 +99,7 @@ contract FlipTest is DSTest {
         vat.set_ilk("gems");
 
         flip = new Flipper(address(vat), "gems");
+        flip.rely(address(this));
 
         ali = address(new Guy(flip));
         bob = address(new Guy(flip));

--- a/src/test/flip.t.sol
+++ b/src/test/flip.t.sol
@@ -99,7 +99,6 @@ contract FlipTest is DSTest {
         vat.set_ilk("gems");
 
         flip = new Flipper(address(vat), "gems");
-        flip.rely(address(this));
 
         ali = address(new Guy(flip));
         bob = address(new Guy(flip));

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -483,6 +483,7 @@ contract BiteTest is DSTest {
         vat.file("gold", "line", rad(1000 ether));
         vat.file("Line",         rad(1000 ether));
         flip = new Flipper(address(vat), "gold");
+        flip.rely(address(cat));
         cat.file("gold", "flip", address(flip));
         cat.file("gold", "chop", ray(1 ether));
 


### PR DESCRIPTION
Current `Flip.kick` is a public function.  It is preferable to only allow the `Cat` to call `kick` to preserve the integrity of auctions