### PR TITLE
ISSUE-335: Explicitly declare compiler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ script: |
   git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
   nix-env -f $HOME/.dapp/dapptools -iA dapp solc
 
-  dapp --use solc:0.5.9 test
+  dapp --use solc:0.5.11 test

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 pragma experimental ABIEncoderV2;
 
 import "./lib.sol";

--- a/src/dai.sol
+++ b/src/dai.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "./lib.sol";
 

--- a/src/end.sol
+++ b/src/end.sol
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 pragma experimental ABIEncoderV2;
 
 import "./lib.sol";

--- a/src/flap.sol
+++ b/src/flap.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "./lib.sol";
 

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "./lib.sol";
 

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "./lib.sol";
 

--- a/src/join.sol
+++ b/src/join.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "./lib.sol";
 

--- a/src/jug.sol
+++ b/src/jug.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 pragma experimental ABIEncoderV2;
 
 import "./lib.sol";

--- a/src/lib.sol
+++ b/src/lib.sol
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity >=0.4.23;
+pragma solidity =0.5.11;
 
 contract DSNote {
     event LogNote(

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "./lib.sol";
 

--- a/src/spot.sol
+++ b/src/spot.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "./lib.sol";
 

--- a/src/test/dai.t.sol
+++ b/src/test/dai.t.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity >=0.4.23;
+pragma solidity =0.5.11;
 
 import "ds-test/test.sol";
 

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "ds-test/test.sol";
 import "ds-token/token.sol";

--- a/src/test/flap.t.sol
+++ b/src/test/flap.t.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "ds-test/test.sol";
 import {DSToken} from "ds-token/token.sol";

--- a/src/test/flip.t.sol
+++ b/src/test/flip.t.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "ds-test/test.sol";
 import {DSToken} from "ds-token/token.sol";

--- a/src/test/flop.t.sol
+++ b/src/test/flop.t.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import {DSTest}  from "ds-test/test.sol";
 import {DSToken} from "ds-token/token.sol";

--- a/src/test/fork.t.sol
+++ b/src/test/fork.t.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "ds-test/test.sol";
 import "ds-token/token.sol";

--- a/src/test/jug.t.sol
+++ b/src/test/jug.t.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 pragma experimental ABIEncoderV2;
 
 import "ds-test/test.sol";

--- a/src/test/pot.t.sol
+++ b/src/test/pot.t.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "ds-test/test.sol";
 import {Vat} from '../vat.sol';

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 pragma experimental ABIEncoderV2;
 
 import "ds-test/test.sol";

--- a/src/test/vow.t.sol
+++ b/src/test/vow.t.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "ds-test/test.sol";
 

--- a/src/vat.sol
+++ b/src/vat.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 contract Vat {
     // --- Auth ---

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "./lib.sol";
 


### PR DESCRIPTION
This PR locks solidity to a very specific version `0.5.11` in preparation for deployment.  We wanted to make sure it was at least `0.5.7` to fix bugs in `ABIEncoderV2`.  We discussed locking to `0.5.9` for `klab`, and ultimately decided to lock to `0.5.11`.