### PR TITLE
Avoid keccak256 in constant

### DIFF
--- a/src/dai.sol
+++ b/src/dai.sol
@@ -48,7 +48,7 @@ contract Dai is DSNote {
 
     // --- EIP712 niceties ---
     bytes32 public DOMAIN_SEPARATOR;
-    bytes32 public PERMIT_TYPEHASH;
+    bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
 
     constructor(uint256 chainId_) public {
         wards[msg.sender] = 1;
@@ -59,9 +59,6 @@ contract Dai is DSNote {
             chainId_,
             address(this)
         ));
-        PERMIT_TYPEHASH = keccak256(
-            "Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)"
-        );
     }
 
     // --- Token ---

--- a/src/dai.sol
+++ b/src/dai.sol
@@ -48,9 +48,7 @@ contract Dai is DSNote {
 
     // --- EIP712 niceties ---
     bytes32 public DOMAIN_SEPARATOR;
-    bytes32 public constant PERMIT_TYPEHASH = keccak256(
-        "Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)"
-    );
+    bytes32 public PERMIT_TYPEHASH;
 
     constructor(uint256 chainId_) public {
         wards[msg.sender] = 1;
@@ -61,6 +59,9 @@ contract Dai is DSNote {
             chainId_,
             address(this)
         ));
+        PERMIT_TYPEHASH = keccak256(
+            "Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)"
+        );
     }
 
     // --- Token ---

--- a/src/dai.sol
+++ b/src/dai.sol
@@ -48,6 +48,7 @@ contract Dai is DSNote {
 
     // --- EIP712 niceties ---
     bytes32 public DOMAIN_SEPARATOR;
+    // bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
     bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
 
     constructor(uint256 chainId_) public {


### PR DESCRIPTION
Solidity 0.5.x still compiles constants as pure functions, which executes on every access