### PR TITLE
Optimize rpow(x,n,base)

### DIFF
--- a/src/jug.sol
+++ b/src/jug.sol
@@ -38,27 +38,30 @@ contract Jug is DSNote {
 
     // --- Math ---
     function rpow(uint x, uint n, uint b) internal pure returns (uint z) {
-      assembly {
-        switch x case 0 {switch n case 0 {z := b} default {z := 0}}
-        default {
-          switch mod(n, 2) case 0 { z := b } default { z := x }
-          let half := div(b, 2)  // for rounding.
-          for { n := div(n, 2) } n { n := div(n,2) } {
-            let xx := mul(x, x)
-            if iszero(eq(div(xx, x), x)) { revert(0,0) }
-            let xxRound := add(xx, half)
-            if lt(xxRound, xx) { revert(0,0) }
-            x := div(xxRound, b)
-            if mod(n,2) {
-              let zx := mul(z, x)
-              if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
-              let zxRound := add(zx, half)
-              if lt(zxRound, zx) { revert(0,0) }
-              z := div(zxRound, b)
+        assembly {
+            switch n case 0 { z := b }
+            default {
+                switch x case 0 { z := 0 }
+                default {
+                    switch mod(n, 2) case 0 { z := b } default { z := x }
+                    let half := div(b, 2)  // for rounding.
+                    for { n := div(n, 2) } n { n := div(n,2) } {
+                        let xx := mul(x, x)
+                        if iszero(eq(div(xx, x), x)) { revert(0,0) }
+                        let xxRound := add(xx, half)
+                        if lt(xxRound, xx) { revert(0,0) }
+                        x := div(xxRound, b)
+                        if mod(n,2) {
+                            let zx := mul(z, x)
+                            if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
+                            let zxRound := add(zx, half)
+                            if lt(zxRound, zx) { revert(0,0) }
+                            z := div(zxRound, b)
+                        }
+                    }
+                }
             }
-          }
         }
-      }
     }
     uint256 constant ONE = 10 ** 27;
     function add(uint x, uint y) internal pure returns (uint z) {

--- a/src/jug.sol
+++ b/src/jug.sol
@@ -47,7 +47,7 @@ contract Jug is DSNote {
                     let half := div(b, 2)  // for rounding.
                     for { n := div(n, 2) } n { n := div(n,2) } {
                         let xx := mul(x, x)
-                        if iszero(eq(div(xx, x), x)) { revert(0,0) }
+                        if shr(128, x) { revert(0,0) }
                         let xxRound := add(xx, half)
                         if lt(xxRound, xx) { revert(0,0) }
                         x := div(xxRound, b)

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -77,22 +77,25 @@ contract Pot is DSNote {
     uint256 constant ONE = 10 ** 27;
     function rpow(uint x, uint n, uint base) internal pure returns (uint z) {
         assembly {
-            switch x case 0 {switch n case 0 {z := base} default {z := 0}}
+            switch n case 0 { z := base }
             default {
-                switch mod(n, 2) case 0 { z := base } default { z := x }
-                let half := div(base, 2)  // for rounding.
-                for { n := div(n, 2) } n { n := div(n,2) } {
-                    let xx := mul(x, x)
-                    if iszero(eq(div(xx, x), x)) { revert(0,0) }
-                    let xxRound := add(xx, half)
-                    if lt(xxRound, xx) { revert(0,0) }
-                    x := div(xxRound, base)
-                    if mod(n,2) {
-                        let zx := mul(z, x)
-                        if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
-                        let zxRound := add(zx, half)
-                        if lt(zxRound, zx) { revert(0,0) }
-                        z := div(zxRound, base)
+                switch x case 0 { z := 0 }
+                default {
+                    switch mod(n, 2) case 0 { z := base } default { z := x }
+                    let half := div(base, 2)  // for rounding.
+                    for { n := div(n, 2) } n { n := div(n,2) } {
+                        let xx := mul(x, x)
+                        if iszero(eq(div(xx, x), x)) { revert(0,0) }
+                        let xxRound := add(xx, half)
+                        if lt(xxRound, xx) { revert(0,0) }
+                        x := div(xxRound, base)
+                        if mod(n,2) {
+                            let zx := mul(z, x)
+                            if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
+                            let zxRound := add(zx, half)
+                            if lt(zxRound, zx) { revert(0,0) }
+                            z := div(zxRound, base)
+                        }
                     }
                 }
             }

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -85,7 +85,7 @@ contract Pot is DSNote {
                     let half := div(base, 2)  // for rounding.
                     for { n := div(n, 2) } n { n := div(n,2) } {
                         let xx := mul(x, x)
-                        if iszero(eq(div(xx, x), x)) { revert(0,0) }
+                        if shr(128, x) { revert(0,0) }
                         let xxRound := add(xx, half)
                         if lt(xxRound, xx) { revert(0,0) }
                         x := div(xxRound, base)


### PR DESCRIPTION
1. Optimize rpow(x,n,base) for the case x != 0 && n == 0 (291 gas vs 383 gas)

    ```Solidity
    switch x case 0 {switch n case 0 {z := b} default {z := 0}}
    default {
       ...
    }
    ```
    =>
    ```Solidity
    switch n case 0 { z := b }
    default {
        switch x case 0 { z := 0 }
        default {
            ...
        }
    }
    ```

2. Simplify overflow check for squaring in rpow(x,n,base) (2355 gas vs 2388 gas for x = 2, n = 255)

    ```Solidity
    let xx := mul(x, x)
    if iszero(eq(div(xx, x), x)) { revert(0,0) }
    ```
    =>
    ```Solidity
    let xx := mul(x, x)
    if shr(128, x) { revert(0,0) }
    ```