### PR TITLE
harden system against interference from governance during global settlement

### DIFF
--- a/src/end.sol
+++ b/src/end.sol
@@ -57,7 +57,6 @@ contract PotLike {
     function cage() external;
 }
 contract VowLike {
-    function heal(uint256 rad) external;
     function cage() external;
 }
 contract Flippy {
@@ -86,6 +85,7 @@ contract Spotty {
     }
     function par() external view returns (uint256);
     function ilks(bytes32) external view returns (Ilk memory);
+    function cage() external;
 }
 
 /*
@@ -191,8 +191,8 @@ contract Spotty {
 contract End is DSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
-    function rely(address guy) external note auth { wards[guy] = 1; }
-    function deny(address guy) external note auth { wards[guy] = 0; }
+    function rely(address guy) external note auth { require(live == 1); wards[guy] = 1; }
+    function deny(address guy) external note auth { require(live == 1); wards[guy] = 0; }
     modifier auth { require(wards[msg.sender] == 1); _; }
 
     // --- Data ---
@@ -249,6 +249,7 @@ contract End is DSNote {
 
     // --- Administration ---
     function file(bytes32 what, address data) external note auth {
+        require(live == 1);
         if (what == "vat")  vat = VatLike(data);
         else if (what == "cat")  cat = CatLike(data);
         else if (what == "vow")  vow = VowLike(data);
@@ -257,6 +258,7 @@ contract End is DSNote {
         else revert();
     }
     function file(bytes32 what, uint256 data) external note auth {
+        require(live == 1);
         if (what == "wait") wait = data;
         else revert();
     }
@@ -269,6 +271,7 @@ contract End is DSNote {
         vat.cage();
         cat.cage();
         vow.cage();
+        spot.cage();
         pot.cage();
     }
 

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -129,7 +129,6 @@ contract Pot is DSNote {
     }
 
     function cage() external note auth {
-        require(live == 1);
         live = 0;
         dsr = ONE;
     }

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -129,6 +129,7 @@ contract Pot is DSNote {
     }
 
     function cage() external note auth {
+        require(live == 1);
         live = 0;
         dsr = ONE;
     }

--- a/src/spot.sol
+++ b/src/spot.sol
@@ -43,6 +43,8 @@ contract Spotter is DSNote {
     VatLike public vat;
     uint256 public par; // ref per dai
 
+    uint256 public live;
+
     // --- Events ---
     event Poke(
       bytes32 ilk,
@@ -55,6 +57,7 @@ contract Spotter is DSNote {
         wards[msg.sender] = 1;
         vat = VatLike(vat_);
         par = ONE;
+        live = 1;
     }
 
     // --- Math ---
@@ -69,14 +72,17 @@ contract Spotter is DSNote {
 
     // --- Administration ---
     function file(bytes32 ilk, bytes32 what, address pip_) external note auth {
+        require(live == 1);
         if (what == "pip") ilks[ilk].pip = PipLike(pip_);
         else revert();
     }
     function file(bytes32 what, uint data) external note auth {
+        require(live == 1);
         if (what == "par") par = data;
         else revert();
     }
     function file(bytes32 ilk, bytes32 what, uint data) external note auth {
+        require(live == 1);
         if (what == "mat") ilks[ilk].mat = data;
         else revert();
     }
@@ -89,5 +95,9 @@ contract Spotter is DSNote {
             vat.file(ilk, "spot", spot);
             emit Poke(ilk, val, spot);
         }
+    }
+
+    function cage() external note auth {
+        live = 0;
     }
 }

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -212,6 +212,7 @@ contract EndTest is DSTest {
         end.file("wait", 1 hours);
         vat.rely(address(end));
         vow.rely(address(end));
+        spot.rely(address(end));
         pot.rely(address(end));
         cat.rely(address(end));
         flap.rely(address(vow));

--- a/src/vat.sol
+++ b/src/vat.sol
@@ -20,8 +20,8 @@ pragma solidity 0.5.11;
 contract Vat {
     // --- Auth ---
     mapping (address => uint) public wards;
-    function rely(address usr) external note auth { wards[usr] = 1; }
-    function deny(address usr) external note auth { wards[usr] = 0; }
+    function rely(address usr) external note auth { require(live == 1); wards[usr] = 1; }
+    function deny(address usr) external note auth { require(live == 1); wards[usr] = 0; }
     modifier auth { require(wards[msg.sender] == 1); _; }
 
     mapping(address => mapping (address => uint)) public can;
@@ -121,10 +121,12 @@ contract Vat {
         ilks[ilk].rate = 10 ** 27;
     }
     function file(bytes32 what, uint data) external note auth {
+        require(live == 1);
         if (what == "Line") Line = data;
         else revert();
     }
     function file(bytes32 ilk, bytes32 what, uint data) external note auth {
+        require(live == 1);
         if (what == "spot") ilks[ilk].spot = data;
         else if (what == "line") ilks[ilk].line = data;
         else if (what == "dust") ilks[ilk].dust = data;

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -41,8 +41,8 @@ contract VatLike {
 contract Vow is DSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
-    function rely(address usr) external note auth { require(live == 1); wards[usr] = 1; }
-    function deny(address usr) external note auth { require(live == 1); wards[usr] = 0; }
+    function rely(address usr) external note auth { wards[usr] = 1; }
+    function deny(address usr) external note auth { wards[usr] = 0; }
     modifier auth { require(wards[msg.sender] == 1); _; }
 
     // --- Data ---

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -41,8 +41,8 @@ contract VatLike {
 contract Vow is DSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
-    function rely(address usr) external note auth { wards[usr] = 1; }
-    function deny(address usr) external note auth { wards[usr] = 0; }
+    function rely(address usr) external note auth { require(live == 1); wards[usr] = 1; }
+    function deny(address usr) external note auth { require(live == 1); wards[usr] = 0; }
     modifier auth { require(wards[msg.sender] == 1); _; }
 
     // --- Data ---
@@ -134,6 +134,7 @@ contract Vow is DSNote {
     }
 
     function cage() external note auth {
+        require(live == 1);
         live = 0;
         Sin = 0;
         Ash = 0;

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -41,7 +41,7 @@ contract VatLike {
 contract Vow is DSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
-    function rely(address usr) external note auth { wards[usr] = 1; }
+    function rely(address usr) external note auth { require(live == 1); wards[usr] = 1; }
     function deny(address usr) external note auth { wards[usr] = 0; }
     modifier auth { require(wards[msg.sender] == 1); _; }
 


### PR DESCRIPTION
Addresses https://github.com/makerdao/smart-contracts-team-pm/issues/331

I tried to make the minimal changes necessary while also erring on the side of caution (so I didn't lock down, for example, `file` calls that wouldn't affect the progression of GS).

Notable breaking change: Spot now has a `cage()` method.