### PR TITLE
Send collateral to Flipper in bite()

### DIFF
--- a/src/cat.sol
+++ b/src/cat.sol
@@ -39,6 +39,7 @@ contract VatLike {
     function ilks(bytes32) external view returns (Ilk memory);
     function urns(bytes32,address) external view returns (Urn memory);
     function grab(bytes32,address,address,address,int,int) external;
+    function flux(bytes32,address,address,uint) external;
     function hope(address) external;
 }
 
@@ -108,7 +109,7 @@ contract Cat is DSNote {
         else revert();
     }
     function file(bytes32 ilk, bytes32 what, address flip) external note auth {
-        if (what == "flip") { ilks[ilk].flip = flip; vat.hope(flip); }
+        if (what == "flip") ilks[ilk].flip = flip;
         else revert();
     }
 
@@ -128,6 +129,7 @@ contract Cat is DSNote {
         vat.grab(ilk, urn, address(this), address(vow), -int(lot), -int(art));
 
         vow.fess(tab);
+        vat.flux(ilk, address(this), ilks[ilk].flip, lot);
         id = Kicker(ilks[ilk].flip).kick({ urn: urn
                                          , gal: address(vow)
                                          , tab: rmul(tab, ilks[ilk].chop)

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -116,8 +116,6 @@ contract Flipper is DSNote {
         bids[id].gal = gal;
         bids[id].tab = tab;
 
-        vat.flux(ilk, msg.sender, address(this), lot);
-
         emit Kick(id, lot, bid, tab, usr, gal);
     }
     function tick(uint id) external note {

--- a/src/test/flip.t.sol
+++ b/src/test/flip.t.sol
@@ -125,6 +125,7 @@ contract FlipTest is DSTest {
         flip.tend(42, 0, 0);
     }
     function test_tend() public {
+        vat.flux("gems", address(this), address(flip), 100 ether);
         uint id = flip.kick({ lot: 100 ether
                             , tab: 50 ether
                             , usr: usr
@@ -167,6 +168,7 @@ contract FlipTest is DSTest {
         assertEq(vat.dai_balance(gal),   1 ether);
     }
     function test_dent() public {
+        vat.flux("gems", address(this), address(flip), 100 ether);
         uint id = flip.kick({ lot: 100 ether
                             , tab: 50 ether
                             , usr: usr
@@ -183,6 +185,7 @@ contract FlipTest is DSTest {
         assertEq(vat.dai_balance(bob),  200 ether);
     }
     function test_beg() public {
+        vat.flux("gems", address(this), address(flip), 100 ether);
         uint id = flip.kick({ lot: 100 ether
                             , tab: 50 ether
                             , usr: usr
@@ -204,6 +207,7 @@ contract FlipTest is DSTest {
         assertTrue( Guy(ali).try_dent(id,  95 ether, 50 ether));
     }
     function test_deal() public {
+        vat.flux("gems", address(this), address(flip), 100 ether);
         uint id = flip.kick({ lot: 100 ether
                             , tab: 50 ether
                             , usr: usr
@@ -217,6 +221,7 @@ contract FlipTest is DSTest {
         hevm.warp(now + 4.1 hours);
         assertTrue( Guy(bob).try_deal(id));
 
+        vat.flux("gems", address(this), address(flip), 100 ether);
         uint ie = flip.kick({ lot: 100 ether
                             , tab: 50 ether
                             , usr: usr
@@ -265,6 +270,7 @@ contract FlipTest is DSTest {
         assertTrue(!Guy(ali).try_deal(id));
     }
     function test_yank_tend() public {
+        vat.flux("gems", address(this), address(flip), 100 ether);
         uint id = flip.kick({ lot: 100 ether
                             , tab: 50 ether
                             , usr: usr
@@ -286,6 +292,7 @@ contract FlipTest is DSTest {
         assertEq(vat.gem_balance(address(this)), 1000 ether);
     }
     function test_yank_dent() public {
+        vat.flux("gems", address(this), address(flip), 100 ether);
         uint id = flip.kick({ lot: 100 ether
                             , tab: 50 ether
                             , usr: usr

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -565,6 +565,7 @@ contract BiteTest is DSTest {
         FlipLike.Bid memory bid = FlipLike(address(flip)).bids(auction);
         assertEq(bid.lot,        40 ether);
         assertEq(bid.tab,   rad(110 ether));
+        assertEq(gem("gold", address(flip)), 40 ether);
     }
     function test_bite_over_lump() public {
         vat.file("gold", 'spot', ray(2.5 ether));
@@ -585,6 +586,7 @@ contract BiteTest is DSTest {
         FlipLike.Bid memory bid = FlipLike(address(flip)).bids(auction);
         assertEq(bid.lot,       30 ether);
         assertEq(bid.tab,   rad(82.5 ether));
+        assertEq(gem("gold", address(flip)), 30 ether);
     }
 
     function test_happy_bite() public {


### PR DESCRIPTION
This removes the need to authorize the Flipper to manipulate the Cat's Vat balances via `hope` in Cat's file method for changing the Flipper of a given ilk.