### PR TITLE
Use Lib- prefix for lib.sol:DSNote to prevent conflicts

### DIFF
--- a/src/cat.sol
+++ b/src/cat.sol
@@ -46,7 +46,7 @@ contract VowLike {
     function fess(uint) external;
 }
 
-contract Cat is LibDSNote {
+contract Cat is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -46,7 +46,7 @@ contract VowLike {
     function fess(uint) external;
 }
 
-contract Cat is DSNote {
+contract Cat is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/dai.sol
+++ b/src/dai.sol
@@ -17,7 +17,7 @@ pragma solidity 0.5.11;
 
 import "./lib.sol";
 
-contract Dai is LibDSNote {
+contract Dai is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address guy) external note auth { wards[guy] = 1; }

--- a/src/dai.sol
+++ b/src/dai.sol
@@ -17,7 +17,7 @@ pragma solidity 0.5.11;
 
 import "./lib.sol";
 
-contract Dai is DSNote {
+contract Dai is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address guy) external note auth { wards[guy] = 1; }

--- a/src/end.sol
+++ b/src/end.sol
@@ -188,7 +188,7 @@ contract Spotty {
         - the number of gems is limited by how big your bag is
 */
 
-contract End is DSNote {
+contract End is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address guy) external note auth { wards[guy] = 1; }

--- a/src/end.sol
+++ b/src/end.sol
@@ -188,7 +188,7 @@ contract Spotty {
         - the number of gems is limited by how big your bag is
 */
 
-contract End is LibDSNote {
+contract End is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address guy) external note auth { wards[guy] = 1; }

--- a/src/flap.sol
+++ b/src/flap.sol
@@ -37,7 +37,7 @@ contract GemLike {
  - `end` max auction duration
 */
 
-contract Flapper is LibDSNote {
+contract Flapper is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/flap.sol
+++ b/src/flap.sol
@@ -37,7 +37,7 @@ contract GemLike {
  - `end` max auction duration
 */
 
-contract Flapper is DSNote {
+contract Flapper is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -38,7 +38,7 @@ contract VatLike {
  - `end` max auction duration
 */
 
-contract Flipper is LibDSNote {
+contract Flipper is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -38,7 +38,7 @@ contract VatLike {
  - `end` max auction duration
 */
 
-contract Flipper is DSNote {
+contract Flipper is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -37,7 +37,7 @@ contract GemLike {
  - `end` max auction duration
 */
 
-contract Flopper is DSNote {
+contract Flopper is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -37,7 +37,7 @@ contract GemLike {
  - `end` max auction duration
 */
 
-contract Flopper is LibDSNote {
+contract Flopper is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/join.sol
+++ b/src/join.sol
@@ -59,7 +59,7 @@ contract VatLike {
 
 */
 
-contract GemJoin is DSNote {
+contract GemJoin is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }
@@ -96,7 +96,7 @@ contract GemJoin is DSNote {
     }
 }
 
-contract ETHJoin is DSNote {
+contract ETHJoin is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }
@@ -128,7 +128,7 @@ contract ETHJoin is DSNote {
     }
 }
 
-contract DaiJoin is DSNote {
+contract DaiJoin is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/join.sol
+++ b/src/join.sol
@@ -59,7 +59,7 @@ contract VatLike {
 
 */
 
-contract GemJoin is LibDSNote {
+contract GemJoin is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }
@@ -96,7 +96,7 @@ contract GemJoin is LibDSNote {
     }
 }
 
-contract ETHJoin is LibDSNote {
+contract ETHJoin is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }
@@ -128,7 +128,7 @@ contract ETHJoin is LibDSNote {
     }
 }
 
-contract DaiJoin is LibDSNote {
+contract DaiJoin is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/jug.sol
+++ b/src/jug.sol
@@ -12,7 +12,7 @@ contract VatLike {
     function fold(bytes32,address,int) external;
 }
 
-contract Jug is LibDSNote {
+contract Jug is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/jug.sol
+++ b/src/jug.sol
@@ -12,7 +12,7 @@ contract VatLike {
     function fold(bytes32,address,int) external;
 }
 
-contract Jug is DSNote {
+contract Jug is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }

--- a/src/lib.sol
+++ b/src/lib.sol
@@ -13,7 +13,7 @@
 
 pragma solidity 0.5.11;
 
-contract LibDSNote {
+contract LibNote {
     event LogNote(
         bytes4   indexed  sig,
         address  indexed  usr,

--- a/src/lib.sol
+++ b/src/lib.sol
@@ -13,7 +13,7 @@
 
 pragma solidity 0.5.11;
 
-contract DSNote {
+contract LibDSNote {
     event LogNote(
         bytes4   indexed  sig,
         address  indexed  usr,

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -43,7 +43,7 @@ contract VatLike {
     function suck(address,address,uint256) external;
 }
 
-contract Pot is DSNote {
+contract Pot is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address guy) external note auth { wards[guy] = 1; }

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -43,7 +43,7 @@ contract VatLike {
     function suck(address,address,uint256) external;
 }
 
-contract Pot is LibDSNote {
+contract Pot is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address guy) external note auth { wards[guy] = 1; }

--- a/src/spot.sol
+++ b/src/spot.sol
@@ -25,7 +25,7 @@ contract PipLike {
     function peek() external returns (bytes32, bool);
 }
 
-contract Spotter is DSNote {
+contract Spotter is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address guy) external note auth { wards[guy] = 1;  }

--- a/src/spot.sol
+++ b/src/spot.sol
@@ -25,7 +25,7 @@ contract PipLike {
     function peek() external returns (bytes32, bool);
 }
 
-contract Spotter is LibDSNote {
+contract Spotter is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address guy) external note auth { wards[guy] = 1;  }

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -38,7 +38,7 @@ contract VatLike {
     function hope(address) external;
 }
 
-contract Vow is LibDSNote {
+contract Vow is LibNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { require(live == 1); wards[usr] = 1; }

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -38,7 +38,7 @@ contract VatLike {
     function hope(address) external;
 }
 
-contract Vow is DSNote {
+contract Vow is LibDSNote {
     // --- Auth ---
     mapping (address => uint) public wards;
     function rely(address usr) external note auth { require(live == 1); wards[usr] = 1; }


### PR DESCRIPTION
The `lib.sol` includes a `DSNote` contract that conflicts with the `dapptools/DSNote` contract.

This becomes an issue when flattening out the `dss-deploy` repo, which depends on the dapptools DSNote contract for `DSPause` and `ESM`, and this `lib.sol:DSNote` for everything else.

We could also add a symbolic prefix in the flattener at build time to prevent the conflict, but that would create a different bytecode output that wouldn't be subject to our FV processes.

Ideally we'd want to have our contract class names match up with our `sol` file names, but since this looks to be a library class I think the simplest solution would be to just add the prefix here.