### PR TITLE
restructuring mul() call

### DIFF
--- a/src/vat.sol
+++ b/src/vat.sol
@@ -173,7 +173,7 @@ contract Vat {
         ilk.Art = add(ilk.Art, dart);
 
         int dtab = mul(ilk.rate, dart);
-        uint tab = mul(urn.art, ilk.rate);
+        uint tab = mul(ilk.rate, urn.art);
         debt     = add(debt, dtab);
 
         // either debt has decreased, or debt ceilings are not exceeded


### PR DESCRIPTION
This flips args of `mul()` for some small gas savings.  We know from line `169` that `ilk.rate` can never be `0`; however, there are many potential times `urn.art` will be `0`.  In the implementation of `mul()` on line `114` we short-circuit the `require()` if `y == 0` thus saving some gas.

**bonus**: The readability is slightly better because of how the arguments are ordered in the call above.

This may be too small an optimization too late in the cycle, but we thought we would bring it up.  Feel free to close.