### PR TITLE
Adds a `view` method for getting current `chi`.

### DIFF
--- a/src/pot.sol
+++ b/src/pot.sol
@@ -146,6 +146,11 @@ contract Pot is LibNote {
         vat.suck(address(vow), address(this), mul(Pie, chi_));
     }
 
+    function drop() external view returns (uint) {
+        if (now == rho) return chi;
+        return rmul(rpow(dsr, now - rho, ONE), chi);
+    }
+
     // --- Savings Dai Management ---
     function join(uint wad) external note {
         require(now == rho, "Pot/rho-not-updated");


### PR DESCRIPTION
This change makes it so a contract with a `view` function can know what `chi` would be in this block.  This is useful for contracts that have view functions that need to return values denominated in DAI when looking at DSR balances.

An example use case for this is a token contract (DAI-GoUp) that wraps DAI held in DSR.  The `balanceOf` function of such a contract (which is `view`) needs to be able to calculate the current balance of an account denominated in DAI.  In order to do this, it must calculate what `chi` _would_ be if `drip` was called this block, but without actually calling `drip` (because that is not a view function).