### PR TITLE
Added comments

### DIFF
--- a/src/cat.sol
+++ b/src/cat.sol
@@ -26,13 +26,13 @@ contract Kicker {
 
 contract VatLike {
     function ilks(bytes32) external view returns (
-        uint256 Art,   // wad
-        uint256 rate,  // ray
-        uint256 spot   // ray
+        uint256 Art,   // [wad]
+        uint256 rate,  // [ray]
+        uint256 spot   // [ray]
     );
     function urns(bytes32,address) external view returns (
-        uint256 ink,   // wad
-        uint256 art    // wad
+        uint256 ink,   // [wad]
+        uint256 art    // [wad]
     );
     function grab(bytes32,address,address,address,int,int) external;
     function hope(address) external;
@@ -62,9 +62,9 @@ contract Cat is LibNote {
 
     mapping (bytes32 => Ilk) public ilks;
 
-    uint256 public live;
-    VatLike public vat;
-    VowLike public vow;
+    uint256 public live; // Access Flag
+    VatLike public vat;  // CDP Engine
+    VowLike public vow;  // Debt Engine
 
     // --- Events ---
     event Bite(

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -62,9 +62,9 @@ contract Cat is LibNote {
 
     mapping (bytes32 => Ilk) public ilks;
 
-    uint256 public live; // Access Flag
-    VatLike public vat;  // CDP Engine
-    VowLike public vow;  // Debt Engine
+    uint256 public live;  // Access Flag
+    VatLike public vat;   // CDP Engine
+    VowLike public vow;   // Debt Engine
 
     // --- Events ---
     event Bite(

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -62,7 +62,7 @@ contract Cat is LibNote {
 
     mapping (bytes32 => Ilk) public ilks;
 
-    uint256 public live;  // Access Flag
+    uint256 public live;  // Shutdown Flag
     VatLike public vat;   // CDP Engine
     VowLike public vow;   // Debt Engine
 

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -62,7 +62,7 @@ contract Cat is LibNote {
 
     mapping (bytes32 => Ilk) public ilks;
 
-    uint256 public live;  // Shutdown Flag
+    uint256 public live;  // Active Flag
     VatLike public vat;   // CDP Engine
     VowLike public vow;   // Debt Engine
 

--- a/src/end.sol
+++ b/src/end.sol
@@ -23,15 +23,15 @@ import "./lib.sol";
 contract VatLike {
     function dai(address) external view returns (uint256);
     function ilks(bytes32 ilk) external returns (
-        uint256 Art,
-        uint256 rate,
-        uint256 spot,
-        uint256 line,
-        uint256 dust
+        uint256 Art,   // [wad]
+        uint256 rate,  // [ray]
+        uint256 spot,  // [ray]
+        uint256 line,  // [rad]
+        uint256 dust   // [rad]
     );
     function urns(bytes32 ilk, address urn) external returns (
-        uint256 ink,
-        uint256 art
+        uint256 ink,   // [wad]
+        uint256 art    // [wad]
     );
     function debt() external returns (uint256);
     function move(address src, address dst, uint256 rad) external;
@@ -43,9 +43,9 @@ contract VatLike {
 }
 contract CatLike {
     function ilks(bytes32) external returns (
-        address flip,  // Liquidator
-        uint256 chop,  // Liquidation Penalty   [ray]
-        uint256 lump   // Liquidation Quantity  [rad]
+        address flip,
+        uint256 chop,  // [ray]
+        uint256 lump   // [rad]
     );
     function cage() external;
 }
@@ -57,14 +57,14 @@ contract VowLike {
 }
 contract Flippy {
     function bids(uint id) external view returns (
-        uint256 bid,
-        uint256 lot,
+        uint256 bid,   // [rad]
+        uint256 lot,   // [wad]
         address guy,
         uint48  tic,
         uint48  end,
         address usr,
         address gal,
-        uint256 tab
+        uint256 tab    // [rad]
     );
     function yank(uint id) external;
 }
@@ -77,7 +77,7 @@ contract Spotty {
     function par() external view returns (uint256);
     function ilks(bytes32) external view returns (
         PipLike pip,
-        uint256 mat
+        uint256 mat    // [ray]
     );
     function cage() external;
 }
@@ -193,24 +193,24 @@ contract End is LibNote {
     }
 
     // --- Data ---
-    VatLike  public vat;
+    VatLike  public vat;   // CDP Engine
     CatLike  public cat;
-    VowLike  public vow;
+    VowLike  public vow;   // Debt Engine
     PotLike  public pot;
     Spotty   public spot;
 
-    uint256  public live;  // cage flag
-    uint256  public when;  // time of cage
-    uint256  public wait;  // processing cooldown length
-    uint256  public debt;  // total outstanding dai following processing [rad]
+    uint256  public live;  // Cage flag
+    uint256  public when;  // Time of cage
+    uint256  public wait;  // Processing Cooldown Length
+    uint256  public debt;  // Total outstanding dai following processing [rad]
 
-    mapping (bytes32 => uint256) public tag;  // cage price           [ray]
-    mapping (bytes32 => uint256) public gap;  // collateral shortfall [wad]
-    mapping (bytes32 => uint256) public Art;  // total debt per ilk   [wad]
-    mapping (bytes32 => uint256) public fix;  // final cash price     [ray]
+    mapping (bytes32 => uint256) public tag;  // Cage price              [ray]
+    mapping (bytes32 => uint256) public gap;  // Collateral shortfall    [wad]
+    mapping (bytes32 => uint256) public Art;  // Total debt per ilk      [wad]
+    mapping (bytes32 => uint256) public fix;  // Final cash price        [ray]
 
-    mapping (address => uint256)                      public bag;  // [wad]
-    mapping (bytes32 => mapping (address => uint256)) public out;  // [wad]
+    mapping (address => uint256)                      public bag;  //    [wad]
+    mapping (bytes32 => mapping (address => uint256)) public out;  //    [wad]
 
     // --- Init ---
     constructor() public {

--- a/src/end.sol
+++ b/src/end.sol
@@ -60,8 +60,8 @@ contract Flippy {
         uint256 bid,   // [rad]
         uint256 lot,   // [wad]
         address guy,
-        uint48  tic,
-        uint48  end,
+        uint48  tic,   // [unix epoch time]
+        uint48  end,   // [unix epoch time]
         address usr,
         address gal,
         uint256 tab    // [rad]
@@ -200,8 +200,8 @@ contract End is LibNote {
     Spotty   public spot;
 
     uint256  public live;  // Cage flag
-    uint256  public when;  // Time of cage
-    uint256  public wait;  // Processing Cooldown Length
+    uint256  public when;  // Time of cage                   [unix epoch time]
+    uint256  public wait;  // Processing Cooldown Length             [seconds]
     uint256  public debt;  // Total outstanding dai following processing [rad]
 
     mapping (bytes32 => uint256) public tag;  // Cage price              [ray]

--- a/src/end.sol
+++ b/src/end.sol
@@ -199,7 +199,7 @@ contract End is LibNote {
     PotLike  public pot;
     Spotty   public spot;
 
-    uint256  public live;  // Cage flag
+    uint256  public live;  // Active Flag
     uint256  public when;  // Time of cage                   [unix epoch time]
     uint256  public wait;  // Processing Cooldown Length             [seconds]
     uint256  public debt;  // Total outstanding dai following processing [rad]

--- a/src/flap.sol
+++ b/src/flap.sol
@@ -66,7 +66,7 @@ contract Flapper is LibNote {
     uint48   public   ttl = 3 hours;  // 3 hours bid duration         [seconds]
     uint48   public   tau = 2 days;   // 2 days total auction length  [seconds]
     uint256  public kicks = 0;
-    uint256  public live;  // Shutdown Flag
+    uint256  public live;  // Active Flag
 
     // --- Events ---
     event Kick(

--- a/src/flap.sol
+++ b/src/flap.sol
@@ -49,8 +49,8 @@ contract Flapper is LibNote {
 
     // --- Data ---
     struct Bid {
-        uint256 bid;
-        uint256 lot;
+        uint256 bid;  // gems paid     [wad]
+        uint256 lot;  // dai for sale  [rad]
         address guy;  // high bidder
         uint48  tic;  // expiry time
         uint48  end;
@@ -58,7 +58,7 @@ contract Flapper is LibNote {
 
     mapping (uint => Bid) public bids;
 
-    VatLike  public   vat;
+    VatLike  public   vat; // CDP Engine
     GemLike  public   gem;
 
     uint256  constant ONE = 1.00E18;
@@ -66,7 +66,7 @@ contract Flapper is LibNote {
     uint48   public   ttl = 3 hours;  // 3 hours bid duration
     uint48   public   tau = 2 days;   // 2 days total auction length
     uint256  public kicks = 0;
-    uint256  public live;
+    uint256  public live;  // Access Flag
 
     // --- Events ---
     event Kick(

--- a/src/flap.sol
+++ b/src/flap.sol
@@ -30,7 +30,7 @@ contract GemLike {
 /*
    This thing lets you sell some dai in return for gems.
 
- - `lot` dai for sale
+ - `lot` dai in return for bid
  - `bid` gems paid
  - `ttl` single bid lifetime
  - `beg` minimum bid increase
@@ -49,11 +49,11 @@ contract Flapper is LibNote {
 
     // --- Data ---
     struct Bid {
-        uint256 bid;  // gems paid            [wad]
-        uint256 lot;  // dai for sale         [rad]
+        uint256 bid;  // gems paid               [wad]
+        uint256 lot;  // dai in return for bid   [rad]
         address guy;  // high bidder
-        uint48  tic;  // bid expiry time      [unix epoch time]
-        uint48  end;  // auction expiry time  [unix epoch time]
+        uint48  tic;  // bid expiry time         [unix epoch time]
+        uint48  end;  // auction expiry time     [unix epoch time]
     }
 
     mapping (uint => Bid) public bids;
@@ -66,7 +66,7 @@ contract Flapper is LibNote {
     uint48   public   ttl = 3 hours;  // 3 hours bid duration
     uint48   public   tau = 2 days;   // 2 days total auction length
     uint256  public kicks = 0;
-    uint256  public live;  // Access Flag
+    uint256  public live;  // Shutdown Flag
 
     // --- Events ---
     event Kick(

--- a/src/flap.sol
+++ b/src/flap.sol
@@ -63,8 +63,8 @@ contract Flapper is LibNote {
 
     uint256  constant ONE = 1.00E18;
     uint256  public   beg = 1.05E18;  // 5% minimum bid increase
-    uint48   public   ttl = 3 hours;  // 3 hours bid duration
-    uint48   public   tau = 2 days;   // 2 days total auction length
+    uint48   public   ttl = 3 hours;  // 3 hours bid duration         [seconds]
+    uint48   public   tau = 2 days;   // 2 days total auction length  [seconds]
     uint256  public kicks = 0;
     uint256  public live;  // Shutdown Flag
 

--- a/src/flap.sol
+++ b/src/flap.sol
@@ -49,16 +49,16 @@ contract Flapper is LibNote {
 
     // --- Data ---
     struct Bid {
-        uint256 bid;  // gems paid     [wad]
-        uint256 lot;  // dai for sale  [rad]
+        uint256 bid;  // gems paid            [wad]
+        uint256 lot;  // dai for sale         [rad]
         address guy;  // high bidder
-        uint48  tic;  // expiry time
-        uint48  end;
+        uint48  tic;  // bid expiry time      [unix epoch time]
+        uint48  end;  // auction expiry time  [unix epoch time]
     }
 
     mapping (uint => Bid) public bids;
 
-    VatLike  public   vat; // CDP Engine
+    VatLike  public   vat;  // CDP Engine
     GemLike  public   gem;
 
     uint256  constant ONE = 1.00E18;
@@ -107,7 +107,7 @@ contract Flapper is LibNote {
 
         bids[id].bid = bid;
         bids[id].lot = lot;
-        bids[id].guy = msg.sender; // configurable??
+        bids[id].guy = msg.sender;  // configurable??
         bids[id].end = add(uint48(now), tau);
 
         vat.move(msg.sender, address(this), lot);

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -50,14 +50,14 @@ contract Flipper is LibNote {
 
     // --- Data ---
     struct Bid {
-        uint256 bid;
-        uint256 lot;
+        uint256 bid;  // dai paid          [rad]
+        uint256 lot;  // gems for sale     [wad]
         address guy;  // high bidder
         uint48  tic;  // expiry time
         uint48  end;
         address usr;
         address gal;
-        uint256 tab;
+        uint256 tab;  // total dai wanted  [rad]
     }
 
     mapping (uint => Bid) public bids;

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -50,14 +50,14 @@ contract Flipper is LibNote {
 
     // --- Data ---
     struct Bid {
-        uint256 bid;  // dai paid          [rad]
-        uint256 lot;  // gems for sale     [wad]
+        uint256 bid;  // dai paid             [rad]
+        uint256 lot;  // gems for sale        [wad]
         address guy;  // high bidder
-        uint48  tic;  // expiry time
-        uint48  end;
+        uint48  tic;  // bid expiry time      [unix epoch time]
+        uint48  end;  // auction expiry time  [unix epoch time]
         address usr;
         address gal;
-        uint256 tab;  // total dai wanted  [rad]
+        uint256 tab;  // total dai wanted    [rad]
     }
 
     mapping (uint => Bid) public bids;
@@ -113,7 +113,7 @@ contract Flipper is LibNote {
 
         bids[id].bid = bid;
         bids[id].lot = lot;
-        bids[id].guy = msg.sender; // configurable??
+        bids[id].guy = msg.sender;  // configurable??
         bids[id].end = add(uint48(now), tau);
         bids[id].usr = usr;
         bids[id].gal = gal;

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -67,8 +67,8 @@ contract Flipper is LibNote {
 
     uint256 constant ONE = 1.00E18;
     uint256 public   beg = 1.05E18;  // 5% minimum bid increase
-    uint48  public   ttl = 3 hours;  // 3 hours bid duration
-    uint48  public   tau = 2 days;   // 2 days total auction length
+    uint48  public   ttl = 3 hours;  // 3 hours bid duration         [seconds]
+    uint48  public   tau = 2 days;   // 2 days total auction length  [seconds]
     uint256 public kicks = 0;
 
     // --- Events ---

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -28,7 +28,7 @@ contract VatLike {
    This thing lets you flip some gems for a given amount of dai.
    Once the given amount of dai is raised, gems are forgone instead.
 
- - `lot` gems for sale
+ - `lot` gems in return for bid
  - `tab` total dai wanted
  - `bid` dai paid
  - `gal` receives dai income
@@ -50,11 +50,11 @@ contract Flipper is LibNote {
 
     // --- Data ---
     struct Bid {
-        uint256 bid;  // dai paid             [rad]
-        uint256 lot;  // gems for sale        [wad]
+        uint256 bid;  // dai paid                 [rad]
+        uint256 lot;  // gems in return for bid   [wad]
         address guy;  // high bidder
-        uint48  tic;  // bid expiry time      [unix epoch time]
-        uint48  end;  // auction expiry time  [unix epoch time]
+        uint48  tic;  // bid expiry time          [unix epoch time]
+        uint48  end;  // auction expiry time      [unix epoch time]
         address usr;
         address gal;
         uint256 tab;  // total dai wanted    [rad]

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -68,7 +68,7 @@ contract Flopper is LibNote {
     uint48   public   ttl = 3 hours;  // 3 hours bid lifetime         [seconds]
     uint48   public   tau = 2 days;   // 2 days total auction length  [seconds]
     uint256  public kicks = 0;
-    uint256  public live;             // Shutdown Flag
+    uint256  public live;             // Active Flag
     address  public vow;              // not used until shutdown
 
     // --- Events ---

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -53,13 +53,13 @@ contract Flopper is LibNote {
         uint256 bid;  // dai paid      [rad]
         uint256 lot;  // gems for sale [wad]
         address guy;  // high bidder
-        uint48  tic;  // expiry time
-        uint48  end;
+        uint48  tic;  // bid expiry time      [unix epoch time]
+        uint48  end;  // auction expiry time  [unix epoch time]
     }
 
     mapping (uint => Bid) public bids;
 
-    VatLike  public   vat; // CDP Engine
+    VatLike  public   vat;  // CDP Engine
     GemLike  public   gem;
 
     uint256  constant ONE = 1.00E18;
@@ -68,8 +68,8 @@ contract Flopper is LibNote {
     uint48   public   ttl = 3 hours;  // 3 hours bid lifetime
     uint48   public   tau = 2 days;   // 2 days total auction length
     uint256  public kicks = 0;
-    uint256  public live;  // Access Flag
-    address  public vow;   // not used until shutdown
+    uint256  public live;             // Access Flag
+    address  public vow;              // not used until shutdown
 
     // --- Events ---
     event Kick(

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -65,8 +65,8 @@ contract Flopper is LibNote {
     uint256  constant ONE = 1.00E18;
     uint256  public   beg = 1.05E18;  // 5% minimum bid increase
     uint256  public   pad = 1.50E18;  // 50% lot increase for tick
-    uint48   public   ttl = 3 hours;  // 3 hours bid lifetime
-    uint48   public   tau = 2 days;   // 2 days total auction length
+    uint48   public   ttl = 3 hours;  // 3 hours bid lifetime         [seconds]
+    uint48   public   tau = 2 days;   // 2 days total auction length  [seconds]
     uint256  public kicks = 0;
     uint256  public live;             // Shutdown Flag
     address  public vow;              // not used until shutdown

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -30,7 +30,7 @@ contract GemLike {
 /*
    This thing creates gems on demand in return for dai.
 
- - `lot` gems for sale
+ - `lot` gems in return for bid
  - `bid` dai paid
  - `gal` receives dai income
  - `ttl` single bid lifetime
@@ -50,11 +50,11 @@ contract Flopper is LibNote {
 
     // --- Data ---
     struct Bid {
-        uint256 bid;  // dai paid      [rad]
-        uint256 lot;  // gems for sale [wad]
+        uint256 bid;  // dai paid                [rad]
+        uint256 lot;  // gems in return for bid  [wad]
         address guy;  // high bidder
-        uint48  tic;  // bid expiry time      [unix epoch time]
-        uint48  end;  // auction expiry time  [unix epoch time]
+        uint48  tic;  // bid expiry time         [unix epoch time]
+        uint48  end;  // auction expiry time     [unix epoch time]
     }
 
     mapping (uint => Bid) public bids;
@@ -68,7 +68,7 @@ contract Flopper is LibNote {
     uint48   public   ttl = 3 hours;  // 3 hours bid lifetime
     uint48   public   tau = 2 days;   // 2 days total auction length
     uint256  public kicks = 0;
-    uint256  public live;             // Access Flag
+    uint256  public live;             // Shutdown Flag
     address  public vow;              // not used until shutdown
 
     // --- Events ---

--- a/src/flop.sol
+++ b/src/flop.sol
@@ -50,8 +50,8 @@ contract Flopper is LibNote {
 
     // --- Data ---
     struct Bid {
-        uint256 bid;
-        uint256 lot;
+        uint256 bid;  // dai paid      [rad]
+        uint256 lot;  // gems for sale [wad]
         address guy;  // high bidder
         uint48  tic;  // expiry time
         uint48  end;
@@ -59,7 +59,7 @@ contract Flopper is LibNote {
 
     mapping (uint => Bid) public bids;
 
-    VatLike  public   vat;
+    VatLike  public   vat; // CDP Engine
     GemLike  public   gem;
 
     uint256  constant ONE = 1.00E18;
@@ -68,8 +68,8 @@ contract Flopper is LibNote {
     uint48   public   ttl = 3 hours;  // 3 hours bid lifetime
     uint48   public   tau = 2 days;   // 2 days total auction length
     uint256  public kicks = 0;
-    uint256  public live;
-    address  public vow;  // not used until shutdown
+    uint256  public live;  // Access Flag
+    address  public vow;   // not used until shutdown
 
     // --- Events ---
     event Kick(

--- a/src/join.sol
+++ b/src/join.sol
@@ -69,8 +69,8 @@ contract GemJoin is LibNote {
         _;
     }
 
-    VatLike public vat;
-    bytes32 public ilk;
+    VatLike public vat;   // CDP Engine
+    bytes32 public ilk;   // Collateral Type
     GemLike public gem;
     uint    public dec;
     uint    public live;  // Access Flag
@@ -109,8 +109,8 @@ contract ETHJoin is LibNote {
         _;
     }
 
-    VatLike public vat;
-    bytes32 public ilk;
+    VatLike public vat;   // CDP Engine
+    bytes32 public ilk;   // Collateral Type
     uint    public live;  // Access Flag
 
     constructor(address vat_, bytes32 ilk_) public {
@@ -144,9 +144,9 @@ contract DaiJoin is LibNote {
         _;
     }
 
-    VatLike public vat;
-    DSTokenLike public dai;
-    uint    public live;  // Access Flag
+    VatLike public vat;      // CDP Engine
+    DSTokenLike public dai;  // Stablecoin Token
+    uint    public live;     // Access Flag
 
     constructor(address vat_, address dai_) public {
         wards[msg.sender] = 1;

--- a/src/join.sol
+++ b/src/join.sol
@@ -73,7 +73,7 @@ contract GemJoin is LibNote {
     bytes32 public ilk;   // Collateral Type
     GemLike public gem;
     uint    public dec;
-    uint    public live;  // Access Flag
+    uint    public live;  // Shutdown Flag
 
     constructor(address vat_, bytes32 ilk_, address gem_) public {
         wards[msg.sender] = 1;
@@ -111,7 +111,7 @@ contract ETHJoin is LibNote {
 
     VatLike public vat;   // CDP Engine
     bytes32 public ilk;   // Collateral Type
-    uint    public live;  // Access Flag
+    uint    public live;  // Shutdown Flag
 
     constructor(address vat_, bytes32 ilk_) public {
         wards[msg.sender] = 1;
@@ -146,7 +146,7 @@ contract DaiJoin is LibNote {
 
     VatLike public vat;      // CDP Engine
     DSTokenLike public dai;  // Stablecoin Token
-    uint    public live;     // Access Flag
+    uint    public live;     // Shutdown Flag
 
     constructor(address vat_, address dai_) public {
         wards[msg.sender] = 1;

--- a/src/join.sol
+++ b/src/join.sol
@@ -73,7 +73,7 @@ contract GemJoin is LibNote {
     bytes32 public ilk;   // Collateral Type
     GemLike public gem;
     uint    public dec;
-    uint    public live;  // Shutdown Flag
+    uint    public live;  // Active Flag
 
     constructor(address vat_, bytes32 ilk_, address gem_) public {
         wards[msg.sender] = 1;
@@ -111,7 +111,7 @@ contract ETHJoin is LibNote {
 
     VatLike public vat;   // CDP Engine
     bytes32 public ilk;   // Collateral Type
-    uint    public live;  // Shutdown Flag
+    uint    public live;  // Active Flag
 
     constructor(address vat_, bytes32 ilk_) public {
         wards[msg.sender] = 1;
@@ -146,7 +146,7 @@ contract DaiJoin is LibNote {
 
     VatLike public vat;      // CDP Engine
     DSTokenLike public dai;  // Stablecoin Token
-    uint    public live;     // Shutdown Flag
+    uint    public live;     // Active Flag
 
     constructor(address vat_, address dai_) public {
         wards[msg.sender] = 1;

--- a/src/jug.sol
+++ b/src/jug.sol
@@ -4,8 +4,8 @@ import "./lib.sol";
 
 contract VatLike {
     function ilks(bytes32) external returns (
-        uint256 Art,   // wad
-        uint256 rate   // ray
+        uint256 Art,   // [wad]
+        uint256 rate   // [ray]
     );
     function fold(bytes32,address,int) external;
 }
@@ -22,14 +22,14 @@ contract Jug is LibNote {
 
     // --- Data ---
     struct Ilk {
-        uint256 duty;
-        uint256  rho;
+        uint256 duty;  // Stability Fee      [ray]
+        uint256  rho;  // Time of last drip  [seconds]
     }
 
     mapping (bytes32 => Ilk) public ilks;
-    VatLike                  public vat;
-    address                  public vow;
-    uint256                  public base;
+    VatLike                  public vat;  // CDP Engine
+    address                  public vow;  // Debt Engine
+    uint256                  public base; // Global Stability Fee [wad]
 
     // --- Init ---
     constructor(address vat_) public {

--- a/src/jug.sol
+++ b/src/jug.sol
@@ -22,14 +22,14 @@ contract Jug is LibNote {
 
     // --- Data ---
     struct Ilk {
-        uint256 duty;  // Stability Fee      [ray]
-        uint256  rho;  // Time of last drip  [seconds]
+        uint256 duty;  // Collateral-specific, per-second stability fee contribution [ray]
+        uint256  rho;  // Time of last drip [unix epoch time]
     }
 
     mapping (bytes32 => Ilk) public ilks;
     VatLike                  public vat;   // CDP Engine
     address                  public vow;   // Debt Engine
-    uint256                  public base;  // Global Stability Fee [wad]
+    uint256                  public base;  // Global, per-second stability fee contribution [ray]
 
     // --- Init ---
     constructor(address vat_) public {

--- a/src/jug.sol
+++ b/src/jug.sol
@@ -27,9 +27,9 @@ contract Jug is LibNote {
     }
 
     mapping (bytes32 => Ilk) public ilks;
-    VatLike                  public vat;  // CDP Engine
-    address                  public vow;  // Debt Engine
-    uint256                  public base; // Global Stability Fee [wad]
+    VatLike                  public vat;   // CDP Engine
+    address                  public vow;   // Debt Engine
+    uint256                  public base;  // Global Stability Fee [wad]
 
     // --- Init ---
     constructor(address vat_) public {

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -56,15 +56,15 @@ contract Pot is LibNote {
     // --- Data ---
     mapping (address => uint256) public pie;  // User Savings Dai [wad]
 
-    uint256 public Pie;  // Total Savings Dai     [wad]
-    uint256 public dsr;  // The Dai Savings Rate  [ray]
-    uint256 public chi;  // The Rate Accumulator  [ray]
+    uint256 public Pie;   // Total Savings Dai     [wad]
+    uint256 public dsr;   // The Dai Savings Rate  [ray]
+    uint256 public chi;   // The Rate Accumulator  [ray]
 
-    VatLike public vat;  // CDP Engine
-    address public vow;  // Debt Engine
-    uint256 public rho;  // Time of last drip     [seconds]
+    VatLike public vat;   // CDP Engine
+    address public vow;   // Debt Engine
+    uint256 public rho;   // Time of last drip     [seconds]
 
-    uint256 public live; // Access Flag
+    uint256 public live;  // Access Flag
 
     // --- Init ---
     constructor(address vat_) public {

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -54,7 +54,7 @@ contract Pot is LibNote {
     }
 
     // --- Data ---
-    mapping (address => uint256) public pie;  // User Savings Dai [wad]
+    mapping (address => uint256) public pie;  // Normalised Savings Dai [wad]
 
     uint256 public Pie;   // Total Savings Dai     [wad]
     uint256 public dsr;   // The Dai Savings Rate  [ray]
@@ -62,9 +62,9 @@ contract Pot is LibNote {
 
     VatLike public vat;   // CDP Engine
     address public vow;   // Debt Engine
-    uint256 public rho;   // Time of last drip     [seconds]
+    uint256 public rho;   // Time of last drip     [unix epoch time]
 
-    uint256 public live;  // Access Flag
+    uint256 public live;  // Shutdown Flag
 
     // --- Init ---
     constructor(address vat_) public {

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -64,7 +64,7 @@ contract Pot is LibNote {
     address public vow;   // Debt Engine
     uint256 public rho;   // Time of last drip     [unix epoch time]
 
-    uint256 public live;  // Shutdown Flag
+    uint256 public live;  // Active Flag
 
     // --- Init ---
     constructor(address vat_) public {

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -54,17 +54,17 @@ contract Pot is LibNote {
     }
 
     // --- Data ---
-    mapping (address => uint256) public pie;  // user Savings Dai
+    mapping (address => uint256) public pie;  // User Savings Dai [wad]
 
-    uint256 public Pie;  // total Savings Dai
-    uint256 public dsr;  // the Dai Savings Rate
-    uint256 public chi;  // the Rate Accumulator
+    uint256 public Pie;  // Total Savings Dai     [wad]
+    uint256 public dsr;  // The Dai Savings Rate  [ray]
+    uint256 public chi;  // The Rate Accumulator  [ray]
 
-    VatLike public vat;  // CDP engine
-    address public vow;  // debt engine
-    uint256 public rho;  // time of last drip
+    VatLike public vat;  // CDP Engine
+    address public vow;  // Debt Engine
+    uint256 public rho;  // Time of last drip     [seconds]
 
-    uint256 public live;  // Access Flag
+    uint256 public live; // Access Flag
 
     // --- Init ---
     constructor(address vat_) public {

--- a/src/pot.sol
+++ b/src/pot.sol
@@ -56,9 +56,9 @@ contract Pot is LibNote {
     // --- Data ---
     mapping (address => uint256) public pie;  // Normalised Savings Dai [wad]
 
-    uint256 public Pie;   // Total Savings Dai     [wad]
-    uint256 public dsr;   // The Dai Savings Rate  [ray]
-    uint256 public chi;   // The Rate Accumulator  [ray]
+    uint256 public Pie;   // Total Normalised Savings Dai  [wad]
+    uint256 public dsr;   // The Dai Savings Rate          [ray]
+    uint256 public chi;   // The Rate Accumulator          [ray]
 
     VatLike public vat;   // CDP Engine
     address public vow;   // Debt Engine

--- a/src/spot.sol
+++ b/src/spot.sol
@@ -37,22 +37,22 @@ contract Spotter is LibNote {
 
     // --- Data ---
     struct Ilk {
-        PipLike pip;
-        uint256 mat;
+        PipLike pip;  // OSM
+        uint256 mat;  // Liquidation ratio [ray]
     }
 
     mapping (bytes32 => Ilk) public ilks;
 
-    VatLike public vat;
-    uint256 public par; // ref per dai
+    VatLike public vat; // CDP Engine
+    uint256 public par; // ref per dai     [ray]
 
     uint256 public live;
 
     // --- Events ---
     event Poke(
       bytes32 ilk,
-      bytes32 val,
-      uint256 spot
+      bytes32 val,  // [wad]
+      uint256 spot  // [ray]
     );
 
     // --- Init ---

--- a/src/spot.sol
+++ b/src/spot.sol
@@ -43,8 +43,8 @@ contract Spotter is LibNote {
 
     mapping (bytes32 => Ilk) public ilks;
 
-    VatLike public vat; // CDP Engine
-    uint256 public par; // ref per dai     [ray]
+    VatLike public vat;  // CDP Engine
+    uint256 public par;  // ref per dai [ray]
 
     uint256 public live;
 

--- a/src/spot.sol
+++ b/src/spot.sol
@@ -37,7 +37,7 @@ contract Spotter is LibNote {
 
     // --- Data ---
     struct Ilk {
-        PipLike pip;  // OSM
+        PipLike pip;  // Price Feed
         uint256 mat;  // Liquidation ratio [ray]
     }
 

--- a/src/vat.sol
+++ b/src/vat.sol
@@ -56,7 +56,7 @@ contract Vat {
     uint256 public debt;  // Total Dai Issued    [rad]
     uint256 public vice;  // Total Unbacked Dai  [rad]
     uint256 public Line;  // Total Debt Ceiling  [rad]
-    uint256 public live;  // Access Flag
+    uint256 public live;  // Shutdown Flag
 
     // --- Logs ---
     event LogNote(

--- a/src/vat.sol
+++ b/src/vat.sol
@@ -56,7 +56,7 @@ contract Vat {
     uint256 public debt;  // Total Dai Issued    [rad]
     uint256 public vice;  // Total Unbacked Dai  [rad]
     uint256 public Line;  // Total Debt Ceiling  [rad]
-    uint256 public live;  // Shutdown Flag
+    uint256 public live;  // Active Flag
 
     // --- Logs ---
     event LogNote(

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -58,14 +58,14 @@ contract Vow is LibNote {
     uint256 public Sin;   // Queued debt            [rad]
     uint256 public Ash;   // On-auction debt        [rad]
 
-    uint256 public wait;  // Flop delay
+    uint256 public wait;  // Flop delay             [seconds]
     uint256 public dump;  // Flop initial lot size  [wad]
     uint256 public sump;  // Flop fixed bid size    [rad]
 
     uint256 public bump;  // Flap fixed lot size    [rad]
     uint256 public hump;  // Surplus buffer         [rad]
 
-    uint256 public live;  // Access Flag
+    uint256 public live;  // Shutdown Flag
 
     // --- Init ---
     constructor(address vat_, address flapper_, address flopper_) public {

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -65,7 +65,7 @@ contract Vow is LibNote {
     uint256 public bump;  // Flap fixed lot size    [rad]
     uint256 public hump;  // Surplus buffer         [rad]
 
-    uint256 public live;  // Shutdown Flag
+    uint256 public live;  // Active Flag
 
     // --- Init ---
     constructor(address vat_, address flapper_, address flopper_) public {

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -54,7 +54,7 @@ contract Vow is LibNote {
     FlapLike public flapper;   // Surplus Auction House
     FlopLike public flopper;   // Debt Auction House
 
-    mapping (uint256 => uint256) public sin; // debt queue
+    mapping (uint256 => uint256) public sin;  // debt queue
     uint256 public Sin;   // Queued debt            [rad]
     uint256 public Ash;   // On-auction debt        [rad]
 

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -50,22 +50,22 @@ contract Vow is LibNote {
     }
 
     // --- Data ---
-    VatLike public vat;
-    FlapLike public flapper;
-    FlopLike public flopper;
+    VatLike public vat;        // CDP Engine
+    FlapLike public flapper;   // Surplus Auction House
+    FlopLike public flopper;   // Debt Auction House
 
     mapping (uint256 => uint256) public sin; // debt queue
-    uint256 public Sin;   // queued debt          [rad]
-    uint256 public Ash;   // on-auction debt      [rad]
+    uint256 public Sin;   // Queued debt            [rad]
+    uint256 public Ash;   // On-auction debt        [rad]
 
-    uint256 public wait;  // flop delay
-    uint256 public dump;  // flop initial lot size  [wad]
-    uint256 public sump;  // flop fixed bid size    [rad]
+    uint256 public wait;  // Flop delay
+    uint256 public dump;  // Flop initial lot size  [wad]
+    uint256 public sump;  // Flop fixed bid size    [rad]
 
-    uint256 public bump;  // flap fixed lot size    [rad]
-    uint256 public hump;  // surplus buffer       [rad]
+    uint256 public bump;  // Flap fixed lot size    [rad]
+    uint256 public hump;  // Surplus buffer         [rad]
 
-    uint256 public live;
+    uint256 public live;  // Access Flag
 
     // --- Init ---
     constructor(address vat_, address flapper_, address flopper_) public {


### PR DESCRIPTION
## Summary
This PR Improves comments within `dss` by adding units and short descriptions where needed.
Requesting reviewers check to ensure consistency and approve as soon as convenient.

## Rationale
A lack of unit awareness infects the developer experience.
Although important data structures are commented (like `Ilk` and `Urn` in the `Vat`), this is not consistent in other contracts used by integration partners, such as the `Spotter` or the `Jug`.

I hope this doesn’t spur any bike shedding, but I think it’s important to add unit context, readily available and in the source code. It saves time and will improve the integration experience immensely. 

## Changes

Following great examples in the `Vat.sol`, I tried to be as consistent with what commenting style has been used:
- Source of variable declaration within contracts - short description + units
- Imports of data structures via interface contracts - units 

For example from `Jug.sol`: 
```
contract VatLike {
    function ilks(bytes32) external returns (
        uint256 Art,   // [wad]
        uint256 rate   // [ray]
    );
    function fold(bytes32,address,int) external;
}

contract Jug is LibNote { 
… 
	struct Ilk {
	     uint256 duty;  // Stability Fee         [ray]
      	     uint256  rho;  // Time of last drip     [seconds]
    	}
… 
}
```

There were also strange variations in uppercase conditions, so I tried to improve consistency in that area as well.

When short descriptions were lacking, I looked to examples within the repo, such as other solidity files or the [Wiki glossary](https://github.com/makerdao/dss/wiki/Glossary)

I’ve also added unit context to `event Poke( ... )` in `spot.sol`, relieving a potential journey outside of `dss`.

