### PR TITLE
SC-4319: adds copyright header to jug.sol

### DIFF
--- a/src/jug.sol
+++ b/src/jug.sol
@@ -1,3 +1,20 @@
+/// jug.sol -- Dai Lending Rate
+
+// Copyright (C) 2018 Rain <rainbreak@riseup.net>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 pragma solidity ^0.5.12;
 
 import "./lib.sol";


### PR DESCRIPTION
We forgot to add the copyright header to `jug.sol`.

I also chose the name `Dai Lending Rate`, to match the counter part in `pot.sol` of `Dai Savings Rate`.