### PR TITLE
SC-4900: support to limit on-auction DAI

### DIFF
--- a/src/cat.sol
+++ b/src/cat.sol
@@ -143,9 +143,6 @@ contract Cat is LibNote {
 
     // --- CDP Liquidation ---
     function bite(bytes32 ilk, address urn) external returns (uint id) {
-        // NOTE: because of stack-depth limits, we need to re-use num in this
-        // function.  At the start, num is spot, then later becomes lot.
-
         (, uint rate, uint spot) = vat.ilks(ilk);
         (uint ink, uint art) = vat.urns(ilk, urn);
 
@@ -166,10 +163,8 @@ contract Cat is LibNote {
         // Pick a fractional art that doesn't put us over box
         uint fart = min(
             art, rdiv((sub(box, litter) / ilkS.chop), rate)
-      //WAD=WAD, WAD       RAD, RAD     / RAY            / RAY
         );
         lot = min(lot, wmul(lot, wdiv(fart, art)));
-      //WAD       WAD, WAD
 
         require(lot <= 2**255 && fart <= 2**255, "Cat/overflow");
         vat.grab(ilk, urn, address(this), address(vow), -int(lot), -int(fart));
@@ -177,7 +172,6 @@ contract Cat is LibNote {
         // Accumulate litter in the box
         uint tab = rmul(mul(fart, rate), ilkS.chop);
         litter = add(litter, tab);
-      //RAD          RAD   , RAD  RAD WAD , RAY  , RAY
 
         vow.fess(mul(fart, rate));
         id = Kicker(ilkS.flip).kick({

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -138,7 +138,6 @@ contract Cat is LibNote {
 
         require(live == 1, "Cat/not-live");
         require(spot > 0 && mul(ink, spot) < mul(art, rate), "Cat/not-unsafe");
-        // TODO(cmooney): test me
         require(litter < box, "Cat/liquidation-limit-hit");
 
         Ilk memory milk = ilks[ilk];

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -26,13 +26,13 @@ interface Kicker {
 
 interface VatLike {
     function ilks(bytes32) external view returns (
-        uint256 Art,   // [wad]
-        uint256 rate,  // [ray]
-        uint256 spot   // [ray]
+        uint256 Art,  // [wad]
+        uint256 rate, // [ray]
+        uint256 spot  // [ray]
     );
     function urns(bytes32,address) external view returns (
-        uint256 ink,   // [wad]
-        uint256 art    // [wad]
+        uint256 ink,  // [wad]
+        uint256 art   // [wad]
     );
     function grab(bytes32,address,address,address,int,int) external;
     function hope(address) external;
@@ -56,17 +56,17 @@ contract Cat is LibNote {
     // --- Data ---
     struct Ilk {
         address flip;  // Liquidator
-        uint256 chop;  // Liquidation Penalty   [ray]
-        uint256 lump;  // Liquidation Quantity  [wad]
+        uint256 chop;  // Liquidation Penalty  [ray]
+        uint256 lump;  // Liquidation Quantity [wad]
     }
 
     mapping (bytes32 => Ilk) public ilks;
 
-    uint256 public box;  // Max Dai out for liquidation [rad]
-    uint256 public litter;  // Balance of Dai out for liquidation [rad]
-    uint256 public live;  // Active Flag
-    VatLike public vat;   // CDP Engine
-    VowLike public vow;   // Debt Engine
+    uint256 public box;    // Max Dai out for liquidation        [rad]
+    uint256 public litter; // Balance of Dai out for liquidation [rad]
+    uint256 public live;   // Active Flag
+    VatLike public vat;    // CDP Engine
+    VowLike public vow;    // Debt Engine
 
     // --- Events ---
     event Bite(
@@ -88,10 +88,10 @@ contract Cat is LibNote {
     }
 
     // --- Math ---
+    uint constant MLN = 10 **  6;
     uint constant WAD = 10 ** 18;
     uint constant RAY = 10 ** 27;
     uint constant RAD = 10 ** 45;
-    uint constant MLN = 10 **  6;
 
     function min(uint x, uint y) internal pure returns (uint z) {
         if (x > y) { z = y; } else { z = x; }
@@ -163,15 +163,15 @@ contract Cat is LibNote {
         // art = ----------------------
         //               rate
         //
-        // pick a fractional art that doesn't put us over box
+        // Pick a fractional art that doesn't put us over box
         uint fart = min(
             art, rdiv((sub(box, litter) / ilks[ilk].chop), rate)
       //WAD=WAD, WAD       RAD, RAD     / RAY            / RAY
         );
         num = min(num, wmul(num, wdiv(fart, art)));
-      //WAD     WAD, WAD
+      //WAD       WAD, WAD
 
-        // accumulate litter in the box
+        // Accumulate litter in the box
         litter = add(litter, rmul(mul(fart, rate), ilks[ilk].chop));
       //RAD          RAD   , RAD  RAD WAD , RAY  , RAY
 

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -62,11 +62,11 @@ contract Cat is LibNote {
 
     mapping (bytes32 => Ilk) public ilks;
 
-    uint256 public box;    // Max Dai out for liquidation        [rad]
-    uint256 public litter; // Balance of Dai out for liquidation [rad]
     uint256 public live;   // Active Flag
     VatLike public vat;    // CDP Engine
     VowLike public vow;    // Debt Engine
+    uint256 public box;    // Max Dai out for liquidation        [rad]
+    uint256 public litter; // Balance of Dai out for liquidation [rad]
 
     // --- Events ---
     event Bite(

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -20,7 +20,7 @@ pragma solidity >=0.5.12;
 import "./lib.sol";
 
 interface Kicker {
-    function kick(address urn, address gal, uint tab, uint lot, uint bid)
+    function kick(address urn, address gal, uint256 tab, uint256 lot, uint256 bid)
         external returns (uint);
 }
 
@@ -88,23 +88,23 @@ contract Cat is LibNote {
     }
 
     // --- Math ---
-    uint constant MLN = 10 **  6;
-    uint constant WAD = 10 ** 18;
-    uint constant RAY = 10 ** 27;
-    uint constant RAD = 10 ** 45;
+    uint256 constant MLN = 10 **  6;
+    uint256 constant WAD = 10 ** 18;
+    uint256 constant RAY = 10 ** 27;
+    uint256 constant RAD = 10 ** 45;
 
-    uint constant MAX_LUMP = uint(-1) / RAY;
+    uint256 constant MAX_LUMP = uint(-1) / RAY;
 
-    function min(uint x, uint y) internal pure returns (uint z) {
+    function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         if (x > y) { z = y; } else { z = x; }
     }
-    function add(uint x, uint y) internal pure returns (uint z) {
+    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x + y) >= x);
     }
-    function sub(uint x, uint y) internal pure returns (uint z) {
+    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x - y) <= x);
     }
-    function mul(uint x, uint y) internal pure returns (uint z) {
+    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require(y == 0 || (z = x * y) / y == x);
     }
 
@@ -113,11 +113,11 @@ contract Cat is LibNote {
         if (what == "vow") vow = VowLike(data);
         else revert("Cat/file-unrecognized-param");
     }
-    function file(bytes32 what, uint data) external note auth {
+    function file(bytes32 what, uint256 data) external note auth {
         if (what == "box") box = data;
         else revert("Cat/file-unrecognized-param");
     }
-    function file(bytes32 ilk, bytes32 what, uint data) external note auth {
+    function file(bytes32 ilk, bytes32 what, uint256 data) external note auth {
         if (what == "chop") ilks[ilk].chop = data;
         else if (what == "lump" && data <= MAX_LUMP) ilks[ilk].lump = data;
         else revert("Cat/file-unrecognized-param");
@@ -132,9 +132,9 @@ contract Cat is LibNote {
     }
 
     // --- CDP Liquidation ---
-    function bite(bytes32 ilk, address urn) external returns (uint id) {
-        (, uint rate, uint spot) = vat.ilks(ilk);
-        (uint ink, uint art) = vat.urns(ilk, urn);
+    function bite(bytes32 ilk, address urn) external returns (uint256 id) {
+        (, uint256 rate, uint256 spot) = vat.ilks(ilk);
+        (uint256 ink, uint256 art) = vat.urns(ilk, urn);
 
         require(live == 1, "Cat/not-live");
         require(spot > 0 && mul(ink, spot) < mul(art, rate), "Cat/not-unsafe");
@@ -142,7 +142,7 @@ contract Cat is LibNote {
 
         Ilk memory milk = ilks[ilk];
 
-        uint limit = min(milk.lump, sub(box, litter));
+        uint256 limit = min(milk.lump, sub(box, litter));
         //   RAD   = RAD(RAD      , RAD(RAD, RAD   ))
         //
         //       limit / rate
@@ -150,9 +150,9 @@ contract Cat is LibNote {
         //           chop
         //
         // pick a fractional art that doesn't fill the box
-        uint fart = min(art, mul(limit, RAY) / rate / milk.chop);
+        uint256 fart = min(art, mul(limit, RAY) / rate / milk.chop);
         //   WAD  = WAD(WAD,WAD=(RAD  , RAY, RAY) / RAY      )
-        uint fink = min(ink, mul(ink, fart) / art);
+        uint256 fink = min(ink, mul(ink, fart) / art);
         //   WAD = WAD(WAD, WAD(WAD, WAD ) / WAD)
 
         require(fink <= 2**255 && fart <= 2**255, "Cat/overflow");
@@ -162,7 +162,7 @@ contract Cat is LibNote {
         { // Avoid stack too deep
             // Accumulate litter in the box
             // TODO: Review if we need to do / RAY first due possible overflow
-            uint tab = mul(mul(fart, rate), milk.chop) / RAY;
+            uint256 tab = mul(mul(fart, rate), milk.chop) / RAY;
             //   RAD =     RAD(WAD,   RAY), RAY      ) / RAY
             litter = add(litter, tab);
 
@@ -178,7 +178,7 @@ contract Cat is LibNote {
         emit Bite(ilk, urn, fink, fart, mul(fart, rate), milk.flip, id);
     }
 
-    function scoop(uint poop) external note auth {
+    function scoop(uint256 poop) external note auth {
         litter = sub(litter, poop);
     }
 

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -138,10 +138,10 @@ contract Cat is LibNote {
         require(spot > 0 && mul(ink, spot) < mul(art, rate), "Cat/not-unsafe");
         require(litter < box, "Cat/liquidation-limit-hit");
 
-        Ilk memory ilkS = ilks[ilk];
+        Ilk memory milk = ilks[ilk];
 
-        uint limit = min(ilkS.lump, sub(box, litter));
-        uint fart = min(art, mul(limit / rate, RAY) / ilkS.chop);
+        uint limit = min(milk.lump, sub(box, litter));
+        uint fart = min(art, mul(limit / rate, RAY) / milk.chop);
         uint lot = min(ink, mul(ink, fart) / art);
 
         require(lot <= 2**255 && fart <= 2**255, "Cat/overflow");
@@ -151,10 +151,10 @@ contract Cat is LibNote {
         { // Avoid stack too deep
             // Accumulate litter in the box
             // TODO: Review if we need to do / RAY first due possible overflow
-            uint tab = mul(mul(fart, rate), ilkS.chop) / RAY;
+            uint tab = mul(mul(fart, rate), milk.chop) / RAY;
             litter = add(litter, tab);
 
-            id = Kicker(ilkS.flip).kick({
+            id = Kicker(milk.flip).kick({
                 urn: urn,
                 gal: address(vow),
                 tab: tab,
@@ -163,7 +163,7 @@ contract Cat is LibNote {
             });
         }
 
-        emit Bite(ilk, urn, lot, fart, mul(fart, rate), ilkS.flip, id);
+        emit Bite(ilk, urn, lot, fart, mul(fart, rate), milk.flip, id);
     }
 
     function scoop(uint poop) external note auth {

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -57,6 +57,7 @@ contract Cat is LibNote {
     struct Ilk {
         address flip;  // Liquidator
         uint256 chop;  // Liquidation Penalty  [ray]
+        // TODO(cmooney): test me
         uint256 lump;  // Liquidation Quantity [rad]
     }
 
@@ -93,6 +94,7 @@ contract Cat is LibNote {
     uint256 constant RAY = 10 ** 27;
     uint256 constant RAD = 10 ** 45;
 
+    // TODO(cmooney): test me
     uint256 constant MAX_LUMP = uint256(-1) / RAY;
 
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
@@ -113,12 +115,14 @@ contract Cat is LibNote {
         if (what == "vow") vow = VowLike(data);
         else revert("Cat/file-unrecognized-param");
     }
+    // TODO(cmooney): test me
     function file(bytes32 what, uint256 data) external note auth {
         if (what == "box") box = data;
         else revert("Cat/file-unrecognized-param");
     }
     function file(bytes32 ilk, bytes32 what, uint256 data) external note auth {
         if (what == "chop") ilks[ilk].chop = data;
+        // TODO(cmooney): test me
         else if (what == "lump" && data <= MAX_LUMP) ilks[ilk].lump = data;
         else revert("Cat/file-unrecognized-param");
     }
@@ -138,6 +142,7 @@ contract Cat is LibNote {
 
         require(live == 1, "Cat/not-live");
         require(spot > 0 && mul(ink, spot) < mul(art, rate), "Cat/not-unsafe");
+        // TODO(cmooney): test me
         require(litter < box, "Cat/liquidation-limit-hit");
 
         Ilk memory milk = ilks[ilk];

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -57,7 +57,6 @@ contract Cat is LibNote {
     struct Ilk {
         address flip;  // Liquidator
         uint256 chop;  // Liquidation Penalty  [ray]
-        // TODO(cmooney): test me
         uint256 lump;  // Liquidation Quantity [rad]
     }
 
@@ -94,7 +93,6 @@ contract Cat is LibNote {
     uint256 constant RAY = 10 ** 27;
     uint256 constant RAD = 10 ** 45;
 
-    // TODO(cmooney): test me
     uint256 constant MAX_LUMP = uint256(-1) / RAY;
 
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
@@ -115,14 +113,12 @@ contract Cat is LibNote {
         if (what == "vow") vow = VowLike(data);
         else revert("Cat/file-unrecognized-param");
     }
-    // TODO(cmooney): test me
     function file(bytes32 what, uint256 data) external note auth {
         if (what == "box") box = data;
         else revert("Cat/file-unrecognized-param");
     }
     function file(bytes32 ilk, bytes32 what, uint256 data) external note auth {
         if (what == "chop") ilks[ilk].chop = data;
-        // TODO(cmooney): test me
         else if (what == "lump" && data <= MAX_LUMP) ilks[ilk].lump = data;
         else revert("Cat/file-unrecognized-param");
     }
@@ -148,7 +144,7 @@ contract Cat is LibNote {
         Ilk memory milk = ilks[ilk];
 
         uint256 limit = min(milk.lump, sub(box, litter));
-        //   RAD   = RAD(RAD      , RAD(RAD, RAD   ))
+        //        RAD = RAD(RAD      , RAD(RAD, RAD   ))
         //
         //       limit / rate
         // art = ------------
@@ -156,9 +152,9 @@ contract Cat is LibNote {
         //
         // pick a fractional art that doesn't fill the box
         uint256 fart = min(art, mul(limit, RAY) / rate / milk.chop);
-        //   WAD  = WAD(WAD,WAD=(RAD  , RAY, RAY) / RAY      )
+        //       WAD = WAD(WAD,WAD=(RAD  , RAY, RAY) / RAY      )
         uint256 fink = min(ink, mul(ink, fart) / art);
-        //   WAD = WAD(WAD, WAD(WAD, WAD ) / WAD)
+        //       WAD = WAD(WAD, WAD(WAD, WAD ) / WAD)
 
         require(fink <= 2**255 && fart <= 2**255, "Cat/overflow");
         vat.grab(ilk, urn, address(this), address(vow), -int256(fink), -int256(fart));
@@ -168,8 +164,9 @@ contract Cat is LibNote {
             // Accumulate litter in the box
             // TODO: Review if we need to do / RAY first due possible overflow
             uint256 tab = mul(mul(fart, rate), milk.chop) / RAY;
-            //   RAD =     RAD(WAD,   RAY), RAY      ) / RAY
+            //      RAD =     RAD(WAD,   RAY), RAY      ) / RAY
             litter = add(litter, tab);
+            // RAD = RAD(RAD   , RAD)
 
             id = Kicker(milk.flip).kick({
                 urn: urn,

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -83,13 +83,10 @@ contract Cat is LibNote {
     constructor(address vat_) public {
         wards[msg.sender] = 1;
         vat = VatLike(vat_);
-        box = 10 * MLN * RAD;
         live = 1;
     }
 
     // --- Math ---
-    uint256 constant MLN = 10 **  6;
-    uint256 constant WAD = 10 ** 18;
     uint256 constant RAY = 10 ** 27;
     uint256 constant RAD = 10 ** 45;
 

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -21,7 +21,7 @@ import "./lib.sol";
 
 interface Kicker {
     function kick(address urn, address gal, uint256 tab, uint256 lot, uint256 bid)
-        external returns (uint);
+        external returns (uint256);
 }
 
 interface VatLike {
@@ -34,18 +34,18 @@ interface VatLike {
         uint256 ink,  // [wad]
         uint256 art   // [wad]
     );
-    function grab(bytes32,address,address,address,int,int) external;
+    function grab(bytes32,address,address,address,int256,int256) external;
     function hope(address) external;
     function nope(address) external;
 }
 
 interface VowLike {
-    function fess(uint) external;
+    function fess(uint256) external;
 }
 
 contract Cat is LibNote {
     // --- Auth ---
-    mapping (address => uint) public wards;
+    mapping (address => uint256) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }
     function deny(address usr) external note auth { wards[usr] = 0; }
     modifier auth {
@@ -93,7 +93,7 @@ contract Cat is LibNote {
     uint256 constant RAY = 10 ** 27;
     uint256 constant RAD = 10 ** 45;
 
-    uint256 constant MAX_LUMP = uint(-1) / RAY;
+    uint256 constant MAX_LUMP = uint256(-1) / RAY;
 
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         if (x > y) { z = y; } else { z = x; }
@@ -156,7 +156,7 @@ contract Cat is LibNote {
         //   WAD = WAD(WAD, WAD(WAD, WAD ) / WAD)
 
         require(fink <= 2**255 && fart <= 2**255, "Cat/overflow");
-        vat.grab(ilk, urn, address(this), address(vow), -int(fink), -int(fart));
+        vat.grab(ilk, urn, address(this), address(vow), -int256(fink), -int256(fart));
         vow.fess(mul(fart, rate));
 
         { // Avoid stack too deep

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -88,7 +88,6 @@ contract Cat is LibNote {
 
     // --- Math ---
     uint256 constant RAY = 10 ** 27;
-    uint256 constant RAD = 10 ** 45;
 
     uint256 constant MAX_LUMP = uint256(-1) / RAY;
 

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -139,29 +139,16 @@ contract Cat is LibNote {
         Ilk memory milk = ilks[ilk];
 
         uint256 limit = min(milk.lump, sub(box, litter));
-        //        RAD = RAD(RAD      , RAD(RAD, RAD   ))
-        //
-        //       limit / rate
-        // art = ------------
-        //           chop
-        //
-        // pick a fractional art that doesn't fill the box
         uint256 fart = min(art, mul(limit, RAY) / rate / milk.chop);
-        //       WAD = WAD(WAD,WAD=(RAD  , RAY, RAY) / RAY      )
         uint256 fink = min(ink, mul(ink, fart) / art);
-        //       WAD = WAD(WAD, WAD(WAD, WAD ) / WAD)
 
         require(fink <= 2**255 && fart <= 2**255, "Cat/overflow");
         vat.grab(ilk, urn, address(this), address(vow), -int256(fink), -int256(fart));
         vow.fess(mul(fart, rate));
 
         { // Avoid stack too deep
-            // Accumulate litter in the box
-            // TODO: Review if we need to do / RAY first due possible overflow
             uint256 tab = mul(mul(fart, rate), milk.chop) / RAY;
-            //      RAD =     RAD(WAD,   RAY), RAY      ) / RAY
             litter = add(litter, tab);
-            // RAD = RAD(RAD   , RAD)
 
             id = Kicker(milk.flip).kick({
                 urn: urn,

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -186,7 +186,6 @@ contract Flipper is LibNote {
     function yank(uint256 id) external note auth {
         require(bids[id].guy != address(0), "Flipper/guy-not-set");
         require(bids[id].bid < bids[id].tab, "Flipper/already-dent-phase");
-        // TODO(cmooney): test me
         cat.scoop(bids[id].tab);
         vat.flux(ilk, address(this), msg.sender, bids[id].lot);
         vat.move(msg.sender, bids[id].guy, bids[id].bid);

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -64,7 +64,7 @@ contract Flipper is LibNote {
         uint256 tab;  // total dai wanted    [rad]
     }
 
-    mapping (uint => Bid) public bids;
+    mapping (uint256 => Bid) public bids;
 
     CatLike public   cat;   // cat liquidation module
     VatLike public   vat;   // vat core accounting
@@ -98,12 +98,12 @@ contract Flipper is LibNote {
     function add(uint48 x, uint48 y) internal pure returns (uint48 z) {
         require((z = x + y) >= x);
     }
-    function mul(uint x, uint y) internal pure returns (uint z) {
+    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require(y == 0 || (z = x * y) / y == x);
     }
 
     // --- Admin ---
-    function file(bytes32 what, uint data) external note auth {
+    function file(bytes32 what, uint256 data) external note auth {
         if (what == "beg") beg = data;
         else if (what == "ttl") ttl = uint48(data);
         else if (what == "tau") tau = uint48(data);
@@ -115,8 +115,8 @@ contract Flipper is LibNote {
     }
 
     // --- Auction ---
-    function kick(address usr, address gal, uint tab, uint lot, uint bid)
-        public auth returns (uint id)
+    function kick(address usr, address gal, uint256 tab, uint256 lot, uint256 bid)
+        public auth returns (uint256 id)
     {
         require(kicks < uint(-1), "Flipper/overflow");
         id = ++kicks;
@@ -133,12 +133,12 @@ contract Flipper is LibNote {
 
         emit Kick(id, lot, bid, tab, usr, gal);
     }
-    function tick(uint id) external note {
+    function tick(uint256 id) external note {
         require(bids[id].end < now, "Flipper/not-finished");
         require(bids[id].tic == 0, "Flipper/bid-already-placed");
         bids[id].end = add(uint48(now), tau);
     }
-    function tend(uint id, uint lot, uint bid) external note {
+    function tend(uint256 id, uint256 lot, uint256 bid) external note {
         require(bids[id].guy != address(0), "Flipper/guy-not-set");
         require(bids[id].tic > now || bids[id].tic == 0, "Flipper/already-finished-tic");
         require(bids[id].end > now, "Flipper/already-finished-end");
@@ -157,7 +157,7 @@ contract Flipper is LibNote {
         bids[id].bid = bid;
         bids[id].tic = add(uint48(now), ttl);
     }
-    function dent(uint id, uint lot, uint bid) external note {
+    function dent(uint256 id, uint256 lot, uint256 bid) external note {
         require(bids[id].guy != address(0), "Flipper/guy-not-set");
         require(bids[id].tic > now || bids[id].tic == 0, "Flipper/already-finished-tic");
         require(bids[id].end > now, "Flipper/already-finished-end");
@@ -176,14 +176,14 @@ contract Flipper is LibNote {
         bids[id].lot = lot;
         bids[id].tic = add(uint48(now), ttl);
     }
-    function deal(uint id) external note {
+    function deal(uint256 id) external note {
         require(bids[id].tic != 0 && (bids[id].tic < now || bids[id].end < now), "Flipper/not-finished");
         cat.scoop(bids[id].tab);
         vat.flux(ilk, address(this), bids[id].guy, bids[id].lot);
         delete bids[id];
     }
 
-    function yank(uint id) external note auth {
+    function yank(uint256 id) external note auth {
         require(bids[id].guy != address(0), "Flipper/guy-not-set");
         require(bids[id].bid < bids[id].tab, "Flipper/already-dent-phase");
         cat.scoop(bids[id].tab);

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -66,9 +66,9 @@ contract Flipper is LibNote {
 
     mapping (uint256 => Bid) public bids;
 
-    CatLike public   cat;   // cat liquidation module
     VatLike public   vat;   // vat core accounting
     bytes32 public   ilk;   // collateral type
+    CatLike public   cat;   // cat liquidation module
 
     uint256 constant ONE = 1.00E18;
     uint256 public   beg = 1.05E18;  // 5% minimum bid increase

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -20,12 +20,12 @@ pragma solidity >=0.5.12;
 import "./lib.sol";
 
 interface VatLike {
-    function move(address,address,uint) external;
-    function flux(bytes32,address,address,uint) external;
+    function move(address,address,uint256) external;
+    function flux(bytes32,address,address,uint256) external;
 }
 
-contract CatLike {
-    function scoop(uint) external;
+interface CatLike {
+    function scoop(uint256) external;
 }
 
 /*
@@ -44,7 +44,7 @@ contract CatLike {
 
 contract Flipper is LibNote {
     // --- Auth ---
-    mapping (address => uint) public wards;
+    mapping (address => uint256) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }
     function deny(address usr) external note auth { wards[usr] = 0; }
     modifier auth {
@@ -118,7 +118,7 @@ contract Flipper is LibNote {
     function kick(address usr, address gal, uint256 tab, uint256 lot, uint256 bid)
         public auth returns (uint256 id)
     {
-        require(kicks < uint(-1), "Flipper/overflow");
+        require(kicks < uint256(-1), "Flipper/overflow");
         id = ++kicks;
 
         bids[id].bid = bid;

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -66,15 +66,15 @@ contract Flipper is LibNote {
 
     mapping (uint256 => Bid) public bids;
 
-    VatLike public   vat;   // vat core accounting
-    bytes32 public   ilk;   // collateral type
-    CatLike public   cat;   // cat liquidation module
+    VatLike public   vat;            // vat core accounting
+    bytes32 public   ilk;            // collateral type
 
     uint256 constant ONE = 1.00E18;
     uint256 public   beg = 1.05E18;  // 5% minimum bid increase
     uint48  public   ttl = 3 hours;  // 3 hours bid duration         [seconds]
     uint48  public   tau = 2 days;   // 2 days total auction length  [seconds]
     uint256 public kicks = 0;
+    CatLike public   cat;            // cat liquidation module
 
     // --- Events ---
     event Kick(

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -61,7 +61,7 @@ contract Flipper is LibNote {
         uint48  end;  // auction expiry time      [unix epoch time]
         address usr;
         address gal;
-        uint256 tab;  // total dai wanted    [rad]
+        uint256 tab;  // total dai wanted         [rad]
     }
 
     mapping (uint256 => Bid) public bids;
@@ -186,6 +186,7 @@ contract Flipper is LibNote {
     function yank(uint256 id) external note auth {
         require(bids[id].guy != address(0), "Flipper/guy-not-set");
         require(bids[id].bid < bids[id].tab, "Flipper/already-dent-phase");
+        // TODO(cmooney): test me
         cat.scoop(bids[id].tab);
         vat.flux(ilk, address(this), msg.sender, bids[id].lot);
         vat.move(msg.sender, bids[id].guy, bids[id].bid);

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -153,7 +153,6 @@ contract Flipper is LibNote {
             bids[id].guy = msg.sender;
         }
         vat.move(msg.sender, bids[id].gal, bid - bids[id].bid);
-        cat.scoop(bid - bids[id].bid);
 
         bids[id].bid = bid;
         bids[id].tic = add(uint48(now), ttl);
@@ -179,6 +178,7 @@ contract Flipper is LibNote {
     }
     function deal(uint id) external note {
         require(bids[id].tic != 0 && (bids[id].tic < now || bids[id].end < now), "Flipper/not-finished");
+        cat.scoop(bids[id].tab);
         vat.flux(ilk, address(this), bids[id].guy, bids[id].lot);
         delete bids[id];
     }
@@ -186,9 +186,9 @@ contract Flipper is LibNote {
     function yank(uint id) external note auth {
         require(bids[id].guy != address(0), "Flipper/guy-not-set");
         require(bids[id].bid < bids[id].tab, "Flipper/already-dent-phase");
+        cat.scoop(bids[id].tab);
         vat.flux(ilk, address(this), msg.sender, bids[id].lot);
         vat.move(msg.sender, bids[id].guy, bids[id].bid);
-        cat.scoop(bids[id].bid);
         delete bids[id];
     }
 }

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -168,7 +168,7 @@ contract EndTest is DSTest {
         cat.rely(address(flip));
         cat.file(name, "flip", address(flip));
         cat.file(name, "chop", ray(1 ether));
-        cat.file(name, "lump", rad(15 ether));
+        cat.file(name, "lump", rad(25000 ether));
 
         ilks[name].pip = pip;
         ilks[name].gem = coin;

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -161,10 +161,11 @@ contract EndTest is DSTest {
 
         vat.rely(address(gemA));
 
-        Flipper flip = new Flipper(address(vat), name);
+        Flipper flip = new Flipper(address(vat), address(cat), name);
         vat.hope(address(flip));
         flip.rely(address(end));
         flip.rely(address(cat));
+        cat.rely(address(flip));
         cat.file(name, "flip", address(flip));
         cat.file(name, "chop", ray(1 ether));
         cat.file(name, "lump", rad(15 ether));

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -96,6 +96,7 @@ contract EndTest is DSTest {
 
     uint constant WAD = 10 ** 18;
     uint constant RAY = 10 ** 27;
+    uint constant MLN = 10 ** 6;
 
     function ray(uint wad) internal pure returns (uint) {
         return wad * 10 ** 9;
@@ -169,6 +170,7 @@ contract EndTest is DSTest {
         cat.file(name, "flip", address(flip));
         cat.file(name, "chop", ray(1 ether));
         cat.file(name, "lump", rad(25000 ether));
+        cat.file("box", rad((10 ether) * MLN));
 
         ilks[name].pip = pip;
         ilks[name].gem = coin;

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -422,7 +422,8 @@ contract EndTest is DSTest {
         // get 1 dai from ali
         ali.move(address(ali), address(this), rad(1 ether));
         vat.hope(address(gold.flip));
-        gold.flip.tend(auction, 10 ether, rad(1 ether)); // bid 1 dai
+        (,uint lot,,,,,,) = gold.flip.bids(auction);
+        gold.flip.tend(auction, lot, rad(1 ether)); // bid 1 dai
         assertEq(dai(urn1), 14 ether);
 
         // collateral price is 5

--- a/src/test/flip.t.sol
+++ b/src/test/flip.t.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.5.12;
 import "ds-test/test.sol";
 
 import {Vat}     from "../vat.sol";
+import {Cat}     from "../cat.sol";
 import {Flipper} from "../flip.sol";
 
 interface Hevm {
@@ -61,6 +62,15 @@ contract Guy {
 
 contract Gal {}
 
+contract Cat_ is Cat {
+    uint256 constant public RAD = 10 ** 45;
+    uint256 constant public MLN = 10 **  6;
+
+    constructor(address vat_) Cat(vat_) public {
+        litter = 5 * MLN * RAD;
+    }
+}
+
 contract Vat_ is Vat {
     function mint(address usr, uint wad) public {
         dai[usr] += wad;
@@ -81,6 +91,7 @@ contract FlipTest is DSTest {
     Hevm hevm;
 
     Vat_    vat;
+    Cat_    cat;
     Flipper flip;
 
     address ali;
@@ -93,11 +104,13 @@ contract FlipTest is DSTest {
         hevm.warp(604411200);
 
         vat = new Vat_();
+        cat = new Cat_(address(vat));
 
         vat.init("gems");
         vat.set_ilk("gems");
 
-        flip = new Flipper(address(vat), "gems");
+        flip = new Flipper(address(vat), address(cat), "gems");
+        cat.rely(address(flip));
 
         ali = address(new Guy(flip));
         bob = address(new Guy(flip));

--- a/src/test/flip.t.sol
+++ b/src/test/flip.t.sol
@@ -99,6 +99,10 @@ contract FlipTest is DSTest {
     address gal;
     address usr = address(0xacab);
 
+    uint256 constant public RAY = 10 ** 27;
+    uint256 constant public RAD = 10 ** 45;
+    uint256 constant public MLN = 10 **  6;
+
     function setUp() public {
         hevm = Hevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
         hevm.warp(604411200);
@@ -123,6 +127,9 @@ contract FlipTest is DSTest {
         vat.slip("gems", address(this), 1000 ether);
         vat.mint(ali, 200 ether);
         vat.mint(bob, 200 ether);
+    }
+    function rad(uint wad) internal pure returns (uint) {
+        return wad * 10 ** 27;
     }
     function test_kick() public {
         flip.kick({ lot: 100 ether
@@ -293,24 +300,33 @@ contract FlipTest is DSTest {
     }
     function test_yank_tend() public {
         uint id = flip.kick({ lot: 100 ether
-                            , tab: 50 ether
+                            , tab: rad(50 ether)
                             , usr: usr
                             , gal: gal
                             , bid: 0
                             });
 
         Guy(ali).tend(id, 100 ether, 1 ether);
+
         // bid taken from bidder
-        assertEq(vat.dai_balance(ali),   199 ether);
-        assertEq(vat.dai_balance(gal),     1 ether);
+        assertEq(vat.dai_balance(ali), 199 ether);
+        assertEq(vat.dai_balance(gal),   1 ether);
+
+        // we have some amount of litter in the box
+        assertEq(cat.litter(), 5 * MLN * RAD);
 
         vat.mint(address(this), 1 ether);
         flip.yank(id);
+
         // bid is refunded to bidder from caller
         assertEq(vat.dai_balance(ali),            200 ether);
         assertEq(vat.dai_balance(address(this)),    0 ether);
+
         // gems go to caller
         assertEq(vat.gem_balance(address(this)), 1000 ether);
+
+        // cat.scoop(tab) is called decrementing the litter accumulator
+        assertEq(cat.litter(), (5 * MLN * RAD) - rad(50 ether));
     }
     function test_yank_dent() public {
         uint id = flip.kick({ lot: 100 ether
@@ -319,11 +335,18 @@ contract FlipTest is DSTest {
                             , gal: gal
                             , bid: 0
                             });
+
+        // we have some amount of litter in the box
+        assertEq(cat.litter(), 5 * MLN * RAD);
+
         Guy(ali).tend(id, 100 ether,  1 ether);
         Guy(bob).tend(id, 100 ether, 50 ether);
         Guy(ali).dent(id,  95 ether, 50 ether);
 
         // cannot yank in the dent phase
         assertTrue(!Guy(ali).try_yank(id));
+
+        // we have same amount of litter in the box
+        assertEq(cat.litter(), 5 * MLN * RAD);
     }
 }

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -595,7 +595,6 @@ contract BiteTest is DSTest {
         flip.dent(auction, 38 ether,  rad(100 ether));
         assertEq(vat.balanceOf(address(this)), 100 ether);
         assertEq(gem("gold", address(this)),   962 ether);
-        assertEq(gem("gold", address(this)),   962 ether);
         assertEq(vow.sin(now),     rad(100 ether));
 
         hevm.warp(now + 4 hours);
@@ -620,15 +619,36 @@ contract BiteTest is DSTest {
 
         cat.file("box", rad(75 ether));             // => box limit 55
         cat.file("gold", "lump", rad(100 ether));   // => try to bite everything
+        assertEq(cat.box(), rad(75 ether));
+        assertEq(cat.litter(), 0);
         uint auction = cat.bite("gold", address(this));
+        assertEq(cat.litter(), rad(75 ether));
         assertEq(ink("gold", address(this)), 50 ether);
         assertEq(art("gold", address(this)), 75 ether);
         assertEq(vow.sin(now), rad(75 ether));
         assertEq(gem("gold", address(this)), 900 ether);
 
-        assertEq(vat.balanceOf(address(vow)), 0 ether);
+        assertEq(vat.balanceOf(address(this)), 150 ether);
+        assertEq(vat.balanceOf(address(vow)),    0 ether);
         flip.tend(auction, 50 ether, rad( 1 ether));
+        assertEq(cat.litter(), rad(75 ether));
+        assertEq(vat.balanceOf(address(this)), 149 ether);
         flip.tend(auction, 50 ether, rad(75 ether));
+        assertEq(vat.balanceOf(address(this)), 75 ether);
+
+        assertEq(gem("gold", address(this)),  900 ether);
+        flip.dent(auction, 25 ether, rad(75 ether));
+        assertEq(cat.litter(), rad(75 ether));
+        assertEq(vat.balanceOf(address(this)), 75 ether);
+        assertEq(gem("gold", address(this)), 925 ether);
+        assertEq(vow.sin(now), rad(75 ether));
+
+        hevm.warp(now + 4 hours);
+        flip.deal(auction);
+        assertEq(cat.litter(), 0);
+        assertEq(gem("gold", address(this)),  950 ether);
+        assertEq(vat.balanceOf(address(this)), 75 ether);
+        assertEq(vat.balanceOf(address(vow)),  75 ether);
     }
 
     function test_floppy_bite() public {

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -529,7 +529,7 @@ contract BiteTest is DSTest {
         // tag=4, mat=2
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
 
-        cat.file("gold", "lump", 50 ether);
+        cat.file("gold", "lump", rad(111 ether));
         cat.file("gold", "chop", ray(1.1 ether));
 
         uint auction = cat.bite("gold", address(this));
@@ -539,7 +539,7 @@ contract BiteTest is DSTest {
         // all debt goes to the vow
         assertEq(vow.Awe(), rad(100 ether));
         // auction is for all collateral
-        (, uint lot,,,,,, uint tab) = FlipLike(address(flip)).bids(auction);
+        (, uint lot,,,,,, uint tab) = flip.bids(auction);
         assertEq(lot,        40 ether);
         assertEq(tab,   rad(110 ether));
     }
@@ -550,7 +550,7 @@ contract BiteTest is DSTest {
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
 
         cat.file("gold", "chop", ray(1.1 ether));
-        cat.file("gold", "lump", 30 ether);
+        cat.file("gold", "lump", rad(82.5 ether));
 
         uint auction = cat.bite("gold", address(this));
         // the CDP is partially liquidated
@@ -578,7 +578,7 @@ contract BiteTest is DSTest {
         assertEq(vow.Woe(), 0 ether);
         assertEq(gem("gold", address(this)), 960 ether);
 
-        cat.file("gold", "lump", 100 ether);  // => bite everything
+        cat.file("gold", "lump", rad(200 ether));  // => bite everything
         uint auction = cat.bite("gold", address(this));
         assertEq(ink("gold", address(this)), 0);
         assertEq(art("gold", address(this)), 0);
@@ -618,8 +618,8 @@ contract BiteTest is DSTest {
         assertEq(vow.Woe(), 0 ether);
         assertEq(gem("gold", address(this)), 900 ether);
 
-        cat.file("box", rad(75 ether));           // => box limit 55
-        cat.file("gold", "lump", 500 ether);      // => try to bite everything
+        cat.file("box", rad(75 ether));             // => box limit 55
+        cat.file("gold", "lump", rad(100 ether));   // => try to bite everything
         uint auction = cat.bite("gold", address(this));
         assertEq(ink("gold", address(this)), 50 ether);
         assertEq(art("gold", address(this)), 75 ether);
@@ -636,7 +636,7 @@ contract BiteTest is DSTest {
         vat.frob("gold", me, me, me, 40 ether, 100 ether);
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
 
-        cat.file("gold", "lump", 100 ether);  // => bite everything
+        cat.file("gold", "lump", rad(200 ether));  // => bite everything
         assertEq(vow.sin(now), rad(  0 ether));
         cat.bite("gold", address(this));
         assertEq(vow.sin(now), rad(100 ether));

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -492,6 +492,7 @@ contract BiteTest is DSTest {
 
         cat = new Cat(address(vat));
         cat.file("vow", address(vow));
+        cat.file("box", rad((10 ether) * MLN));
         vat.rely(address(cat));
         vow.rely(address(cat));
 

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -530,7 +530,7 @@ contract BiteTest is DSTest {
         (,, uint256 goldLump) = cat.ilks("gold");
         assertEq(goldLump, rad(115792 ether));
         cat.file("silver", "lump", rad(115792 ether));
-        (,, uint256 silverLump) = cat.ilks("gold");
+        (,, uint256 silverLump) = cat.ilks("silver");
         assertEq(silverLump, rad(115792 ether));
     }
     function testFail_lump_too_large() public {

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -505,8 +505,9 @@ contract BiteTest is DSTest {
         vat.file("gold", "spot", ray(1 ether));
         vat.file("gold", "line", rad(1000 ether));
         vat.file("Line",         rad(1000 ether));
-        flip = new Flipper(address(vat), "gold");
+        flip = new Flipper(address(vat), address(cat), "gold");
         flip.rely(address(cat));
+        cat.rely(address(flip));
         cat.file("gold", "flip", address(flip));
         cat.file("gold", "chop", ray(1 ether));
 

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -603,6 +603,34 @@ contract BiteTest is DSTest {
         assertEq(vat.balanceOf(address(vow)),  100 ether);
     }
 
+    // tests a partial lot liquidation because it would fill the literbox
+    function test_partial_litterbox() public {
+        // spot = tag / (par . mat)
+        // tag=5, mat=2
+        vat.file("gold", 'spot', ray(2.5 ether));
+        vat.frob("gold", me, me, me, 100 ether, 150 ether);
+
+        // tag=4, mat=2
+        vat.file("gold", 'spot', ray(1 ether));  // now unsafe
+
+        assertEq(ink("gold", address(this)), 100 ether);
+        assertEq(art("gold", address(this)), 150 ether);
+        assertEq(vow.Woe(), 0 ether);
+        assertEq(gem("gold", address(this)), 900 ether);
+
+        cat.file("box", rad(75 ether));           // => box limit 55
+        cat.file("gold", "lump", 500 ether);      // => try to bite everything
+        uint auction = cat.bite("gold", address(this));
+        assertEq(ink("gold", address(this)), 50 ether);
+        assertEq(art("gold", address(this)), 75 ether);
+        assertEq(vow.sin(now), rad(75 ether));
+        assertEq(gem("gold", address(this)), 900 ether);
+
+        assertEq(vat.balanceOf(address(vow)), 0 ether);
+        flip.tend(auction, 50 ether, rad( 1 ether));
+        flip.tend(auction, 50 ether, rad(75 ether));
+    }
+
     function test_floppy_bite() public {
         vat.file("gold", 'spot', ray(2.5 ether));
         vat.frob("gold", me, me, me, 40 ether, 100 ether);


### PR DESCRIPTION
This PR adds support to limit the amount of on-auction Dai.

Governance sets the variable `box` to be the maximum amount of Dai out for auction at any given time.  As under-collateralized Vaults are sent to auction, an accumulator `litter` is incremented.  Once the `litter` fills the `box`, the `cat` can no longer `bite` thus pausing liquidations.  As Dai is reclaimed in `flip` auctions, `scoop()` is called to decrement the `litter` in the `box`; thus making room for more liquidations.