### PR TITLE
SC-5246: Further Improvements for LIQ-1.2

### DIFF
--- a/src/cat.sol
+++ b/src/cat.sol
@@ -152,6 +152,7 @@ contract Cat is LibNote {
 
             dart = min(art, mul(min(milk.dunk, room), RAY) / rate / milk.chop);
         }
+        require(dart > 0, "Cat/null-auction");
 
         uint256 dink = min(ink, mul(ink, dart) / art);
 

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -145,11 +145,11 @@ contract Cat is LibNote {
 
             dart = min(art, mul(min(milk.dunk, room), WAD) / rate / milk.chop);
         }
-        require(dart > 0, "Cat/null-auction");
 
         uint256 dink = min(ink, mul(ink, dart) / art);
 
-        require(dink <= 2**255 && dart <= 2**255, "Cat/overflow");
+        require(dart >  0      && dink >  0     , "Cat/null-auction");
+        require(dart <= 2**255 && dink <= 2**255, "Cat/overflow"    );
 
         // This may leave the CDP in a dusty state
         vat.grab(

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -59,7 +59,7 @@ contract Cat is LibNote {
     struct Ilk {
         address flip;  // Liquidator
         uint256 chop;  // Liquidation Penalty  [ray]
-        uint256 lump;  // Liquidation Quantity [rad]
+        uint256 dunk;  // Liquidation Quantity [rad]
     }
 
     mapping (bytes32 => Ilk) public ilks;
@@ -91,7 +91,7 @@ contract Cat is LibNote {
     // --- Math ---
     uint256 constant RAY = 10 ** 27;
 
-    uint256 constant MAX_LUMP = uint256(-1) / RAY;
+    uint256 constant MAX_DUNK = uint256(-1) / RAY;
 
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         if (x > y) { z = y; } else { z = x; }
@@ -122,7 +122,7 @@ contract Cat is LibNote {
     }
     function file(bytes32 ilk, bytes32 what, uint256 data) external note auth {
         if (what == "chop") ilks[ilk].chop = data;
-        else if (what == "lump" && data <= MAX_LUMP) ilks[ilk].lump = data;
+        else if (what == "dunk" && data <= MAX_DUNK) ilks[ilk].dunk = data;
         else revert("Cat/file-unrecognized-param");
     }
     function file(bytes32 ilk, bytes32 what, address flip) external note auth {
@@ -153,7 +153,7 @@ contract Cat is LibNote {
 
         Ilk memory milk = ilks[ilk];
 
-        uint256 limit = min(milk.lump, sub(box, litter));
+        uint256 limit = min(milk.dunk, sub(box, litter));
         uint256 dart  = min(art, mul(limit, RAY) / rate / milk.chop);
         // TODO(cmooney): make sure test_partial_litterbox_multiple_bites()
         // finds this.

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -25,7 +25,7 @@ interface VatLike {
 }
 
 interface CatLike {
-    function scoop(uint256) external;
+    function claw(uint256) external;
 }
 
 /*
@@ -66,7 +66,7 @@ contract Flipper is LibNote {
 
     mapping (uint256 => Bid) public bids;
 
-    VatLike public   vat;            // vat core accounting
+    VatLike public   vat;            // CDP Engine
     bytes32 public   ilk;            // collateral type
 
     uint256 constant ONE = 1.00E18;
@@ -178,7 +178,7 @@ contract Flipper is LibNote {
     }
     function deal(uint256 id) external note {
         require(bids[id].tic != 0 && (bids[id].tic < now || bids[id].end < now), "Flipper/not-finished");
-        cat.scoop(bids[id].tab);
+        cat.claw(bids[id].tab);
         vat.flux(ilk, address(this), bids[id].guy, bids[id].lot);
         delete bids[id];
     }
@@ -186,7 +186,7 @@ contract Flipper is LibNote {
     function yank(uint256 id) external note auth {
         require(bids[id].guy != address(0), "Flipper/guy-not-set");
         require(bids[id].bid < bids[id].tab, "Flipper/already-dent-phase");
-        cat.scoop(bids[id].tab);
+        cat.claw(bids[id].tab);
         vat.flux(ilk, address(this), msg.sender, bids[id].lot);
         vat.move(msg.sender, bids[id].guy, bids[id].bid);
         delete bids[id];

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -168,7 +168,7 @@ contract EndTest is DSTest {
         flip.rely(address(cat));
         cat.rely(address(flip));
         cat.file(name, "flip", address(flip));
-        cat.file(name, "chop", ray(1 ether));
+        cat.file(name, "chop", 1 ether);
         cat.file(name, "dunk", rad(25000 ether));
         cat.file("box", rad((10 ether) * MLN));
 

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -169,7 +169,7 @@ contract EndTest is DSTest {
         cat.rely(address(flip));
         cat.file(name, "flip", address(flip));
         cat.file(name, "chop", ray(1 ether));
-        cat.file(name, "lump", rad(25000 ether));
+        cat.file(name, "dunk", rad(25000 ether));
         cat.file("box", rad((10 ether) * MLN));
 
         ilks[name].pip = pip;

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -800,7 +800,7 @@ contract BiteTest is DSTest {
         vat.file("gold", 'spot', ray(1 ether));  // now unsafe
 
         // slightly contrived value to leave tiny amount of room post-liquidation
-        cat.file("box", rad(1130 ether) + 1);  
+        cat.file("box", rad(1130 ether) + 1);
         cat.file("gold", "dunk", rad(1130 ether));
         cat.file("gold", "chop", 1.13 ether);
         cat.bite("gold", me);
@@ -842,6 +842,52 @@ contract BiteTest is DSTest {
         // The dustiness check on room doesn't apply here, so additional
         // logic is needed to make this test pass.
         cat.bite("gold", me);
+    }
+
+    function testFail_null_spot_value() public {
+        // spot = tag / (par . mat)
+        // tag=5, mat=2
+        vat.file("gold", 'spot', ray(2.5 ether));
+        vat.frob("gold", me, me, me, 100 ether, 150 ether);
+
+        vat.file("gold", 'spot', ray(1 ether));  // now unsafe
+
+        assertEq(ink("gold", address(this)), 100 ether);
+        assertEq(art("gold", address(this)), 150 ether);
+        assertEq(vow.Woe(), 0 ether);
+        assertEq(gem("gold", address(this)), 900 ether);
+
+        cat.file("gold", "dunk", rad(75 ether));
+        assertEq(cat.litter(), 0);
+        cat.bite("gold", address(this));
+        assertEq(cat.litter(), rad(75 ether));
+        assertEq(ink("gold", address(this)), 50 ether);
+        assertEq(art("gold", address(this)), 75 ether);
+        assertEq(vow.sin(now), rad(75 ether));
+        assertEq(gem("gold", address(this)), 900 ether);
+
+        vat.file("gold", 'spot', 0);
+
+        // this should fail because spot is 0
+        cat.bite("gold", address(this));
+    }
+
+    function testFail_vault_is_safe() public {
+        // spot = tag / (par . mat)
+        // tag=5, mat=2
+        vat.file("gold", 'spot', ray(2.5 ether));
+        vat.frob("gold", me, me, me, 100 ether, 150 ether);
+
+        assertEq(ink("gold", address(this)), 100 ether);
+        assertEq(art("gold", address(this)), 150 ether);
+        assertEq(vow.Woe(), 0 ether);
+        assertEq(gem("gold", address(this)), 900 ether);
+
+        cat.file("gold", "dunk", rad(75 ether));
+        assertEq(cat.litter(), 0);
+
+        // this should fail because the vault is safe
+        cat.bite("gold", address(this));
     }
 
     function test_floppy_bite() public {

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -528,12 +528,12 @@ contract BiteTest is DSTest {
     }
 
     function test_set_dunk_multiple_ilks() public {
-        cat.file("gold",   "dunk", rad(115792 ether));
-        (,, uint256 goldLump) = cat.ilks("gold");
-        assertEq(goldLump, rad(115792 ether));
-        cat.file("silver", "dunk", rad(115792 ether));
-        (,, uint256 silverLump) = cat.ilks("silver");
-        assertEq(silverLump, rad(115792 ether));
+        cat.file("gold",   "dunk", rad(111111 ether));
+        (,, uint256 goldDunk) = cat.ilks("gold");
+        assertEq(goldDunk, rad(111111 ether));
+        cat.file("silver", "dunk", rad(222222 ether));
+        (,, uint256 silverDunk) = cat.ilks("silver");
+        assertEq(silverDunk, rad(222222 ether));
     }
     function test_cat_set_box() public {
         assertEq(cat.box(), rad((10 ether) * MLN));
@@ -703,6 +703,53 @@ contract BiteTest is DSTest {
         assertEq(gem("gold", address(this)), 900 ether);
 
         // this bite puts us over the litterbox
+        cat.bite("gold", address(this));
+    }
+
+    // Tests for multiple bites where second bite has a dusty amount for room
+    function testFail_dusty_litterbox() public {
+        // spot = tag / (par . mat)
+        // tag=5, mat=2
+        vat.file("gold", 'spot', ray(2.5 ether));
+        vat.frob("gold", me, me, me, 50 ether, 80 ether + 1);
+
+        // tag=4, mat=2
+        vat.file("gold", 'spot', ray(1 ether));  // now unsafe
+
+        assertEq(ink("gold", address(this)), 50 ether);
+        assertEq(art("gold", address(this)), 80 ether + 1);
+        assertEq(vow.Woe(), 0 ether);
+        assertEq(gem("gold", address(this)), 950 ether);
+
+        cat.file("box",  rad(100 ether));
+        vat.file("gold", "dust", rad(20 ether));
+        cat.file("gold", "dunk", rad(100 ether));
+
+        assertEq(cat.box(), rad(100 ether));
+        assertEq(cat.litter(), 0);
+        cat.bite("gold", address(this));
+        assertEq(cat.litter(), rad(80 ether + 1)); // room is now dusty
+        assertEq(ink("gold", address(this)), 0 ether);
+        assertEq(art("gold", address(this)), 0 ether);
+        assertEq(vow.sin(now), rad(80 ether + 1));
+        assertEq(gem("gold", address(this)), 950 ether);
+
+        // spot = tag / (par . mat)
+        // tag=5, mat=2
+        vat.file("gold", 'spot', ray(2.5 ether));
+        vat.frob("gold", me, me, me, 100 ether, 150 ether);
+
+        // tag=4, mat=2
+        vat.file("gold", 'spot', ray(1 ether));  // now unsafe
+
+        assertEq(ink("gold", address(this)), 100 ether);
+        assertEq(art("gold", address(this)), 150 ether);
+        assertEq(vow.Woe(), 0 ether);
+        assertEq(gem("gold", address(this)), 850 ether);
+
+        assertTrue(cat.box() - cat.litter() < rad(20 ether)); // room < dust
+
+        // // this bite puts us over the litterbox
         cat.bite("gold", address(this));
     }
 

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -513,7 +513,7 @@ contract BiteTest is DSTest {
         flip.rely(address(cat));
         cat.rely(address(flip));
         cat.file("gold", "flip", address(flip));
-        cat.file("gold", "chop", ray(1 ether));
+        cat.file("gold", "chop", 1 ether);
 
         vat.rely(address(flip));
         vat.rely(address(flap));
@@ -535,48 +535,10 @@ contract BiteTest is DSTest {
         (,, uint256 silverLump) = cat.ilks("silver");
         assertEq(silverLump, rad(115792 ether));
     }
-    function testFail_dunk_too_large() public {
-        // 115792.089237316195423570985008687907853269984665640 * RAD + 1
-        cat.file("gold", "dunk", uint256(-1) / 10 ** 27 + 1);
-    }
     function test_cat_set_box() public {
         assertEq(cat.box(), rad((10 ether) * MLN));
         cat.file("box", rad((20 ether) * MLN));
         assertEq(cat.box(), rad((20 ether) * MLN));
-    }
-    function test_bite_max_dunk() public {
-        uint256 MAX_LUMP = uint256(-1) / 10 ** 27;
-        cat.file("gold", "dunk", MAX_LUMP);
-        cat.file("box", uint256(-1));
-
-        vat.file("Line", rad(300000 ether));
-        vat.file("gold", "line", rad(300000 ether));
-        vat.file("gold", 'spot', ray(205 ether));
-        vat.frob("gold", me, me, me, 1000 ether, 200000 ether);
-
-        vat.file("gold", 'spot', ray(2 ether));  // now unsafe
-
-        uint256 auction = cat.bite("gold", address(this));
-        (,,,,,,, uint256 tab) = flip.bids(auction);
-        assertEq(tab, MAX_LUMP / 10 ** 27 * 10 ** 27);
-    }
-    function testFail_bite_forced_over_max_dunk() public {
-        uint256 MAX_LUMP = uint256(-1) / 10 ** 27;
-        hevm.store(
-            address(cat),
-            bytes32(uint256(keccak256(abi.encode(bytes32("gold"), uint256(1)))) + 2),
-            bytes32(MAX_LUMP + 1)
-        );
-        cat.file("box", uint256(-1));
-
-        vat.file("Line", rad(300000 ether));
-        vat.file("gold", "line", rad(300000 ether));
-        vat.file("gold", 'spot', ray(205 ether));
-        vat.frob("gold", me, me, me, 1000 ether, 200000 ether);
-
-        vat.file("gold", 'spot', ray(2 ether));  // now unsafe
-
-        cat.bite("gold", address(this));
     }
     function test_bite_under_dunk() public {
         vat.file("gold", 'spot', ray(2.5 ether));
@@ -585,7 +547,7 @@ contract BiteTest is DSTest {
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
 
         cat.file("gold", "dunk", rad(111 ether));
-        cat.file("gold", "chop", ray(1.1 ether));
+        cat.file("gold", "chop", 1.1 ether);
 
         uint auction = cat.bite("gold", address(this));
         // the full CDP is liquidated
@@ -604,7 +566,7 @@ contract BiteTest is DSTest {
         // tag=4, mat=2
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
 
-        cat.file("gold", "chop", ray(1.1 ether));
+        cat.file("gold", "chop", 1.1 ether);
         cat.file("gold", "dunk", rad(82.5 ether));
 
         uint auction = cat.bite("gold", address(this));
@@ -627,7 +589,7 @@ contract BiteTest is DSTest {
 
         // tag=4, mat=2
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
-        cat.file("gold", "chop", ray(1.1 ether));
+        cat.file("gold", "chop", 1.1 ether);
 
         assertEq(ink("gold", address(this)),  40 ether);
         assertEq(art("gold", address(this)), 100 ether);
@@ -671,7 +633,7 @@ contract BiteTest is DSTest {
 
         // tag=4, mat=2
         vat.file("gold", 'spot', ray(1 ether));  // now unsafe
-        // cat.file("gold", "chop", ray(1.1 ether));
+        // cat.file("gold", "chop", 1.1 ether);
 
         assertEq(ink("gold", address(this)), 100 ether);
         assertEq(art("gold", address(this)), 150 ether);
@@ -840,14 +802,14 @@ contract BiteTest is DSTest {
         // slightly contrived value to leave tiny amount of room post-liquidation
         cat.file("box", rad(1130 ether) + 1);  
         cat.file("gold", "dunk", rad(1130 ether));
-        cat.file("gold", "chop", ray(1.13 ether));
+        cat.file("gold", "chop", 1.13 ether);
         cat.bite("gold", me);
         assertEq(cat.litter(), rad(1130 ether));
         uint room = cat.box() - cat.litter();
         assertEq(room, 1);
         (, uint256 rate,,,) = vat.ilks("gold");
         (, uint256 chop,) = cat.ilks("gold");
-        assertEq(room * ray(1 ether) / rate / chop, 0);
+        assertEq(room * (1 ether) / rate / chop, 0);
 
         // Biting any non-zero amount of debt would overflow the box,
         // so this should revert and not create a null auction.
@@ -866,14 +828,14 @@ contract BiteTest is DSTest {
         // contrived value to leave tiny amount of room post-liquidation
         cat.file("box", rad(113 ether) + 2);
         cat.file("gold", "dunk", rad(113  ether));
-        cat.file("gold", "chop", ray(1.13 ether));
+        cat.file("gold", "chop", 1.13 ether);
         cat.bite("gold", me);
         assertEq(cat.litter(), rad(113 ether));
         uint room = cat.box() - cat.litter();
         assertEq(room, 2);
         (, uint256 rate,,,) = vat.ilks("gold");
         (, uint256 chop,) = cat.ilks("gold");
-        assertEq(room * ray(1 ether) / rate / chop, 0);
+        assertEq(room * (1 ether) / rate / chop, 0);
 
         // Biting any non-zero amount of debt would overflow the box,
         // so this should revert and not create a null auction.

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -789,7 +789,7 @@ contract BiteTest is DSTest {
         assertEq(vat.balanceOf(address(vow)),  150 ether);
     }
 
-    function testFail_null_auctions_realistic_values() public {
+    function testFail_null_auctions_dart_realistic_values() public {
         vat.file("gold", "dust", rad(100 ether));
         vat.file("gold", "spot", ray(2.5 ether));
         vat.file("gold", "line", rad(2000 ether));
@@ -817,7 +817,7 @@ contract BiteTest is DSTest {
         cat.bite("gold", me);
     }
 
-    function testFail_null_auctions_artificial_values() public {
+    function testFail_null_auctions_dart_artificial_values() public {
         // artificially tiny dust value, e.g. due to misconfiguration
         vat.file("dust", "dust", 1);
         vat.file("gold", "spot", ray(2.5 ether));
@@ -841,6 +841,35 @@ contract BiteTest is DSTest {
         // so this should revert and not create a null auction.
         // The dustiness check on room doesn't apply here, so additional
         // logic is needed to make this test pass.
+        cat.bite("gold", me);
+    }
+
+    function testFail_null_auctions_dink_artificial_values() public {
+        // we're going to make 1 wei of ink worth 250
+        vat.file("gold", "spot", ray(250 ether) * 1 ether);
+        cat.file("gold", "dunk", rad(50 ether));
+        vat.frob("gold", me, me, me, 1, 100 ether);
+
+        vat.file("gold", 'spot', 1);  // massive price crash, now unsafe
+
+        // This should leave us with 0 dink value, and fail
+        cat.bite("gold", me);
+    }
+
+    function testFail_null_auctions_dink_artificial_values_2() public {
+        vat.file("gold", "spot", ray(2000 ether));
+        vat.file("gold", "line", rad(20000 ether));
+        vat.file("Line",         rad(20000 ether));
+        vat.frob("gold", me, me, me, 10 ether, 15000 ether);
+
+        cat.file("box", rad(1000000 ether));  // plenty of room
+
+        // misconfigured dunk (e.g. precision factor incorrect in spell)
+        cat.file("gold", "dunk", rad(100));
+
+        vat.file("gold", 'spot', ray(1000 ether));  // now unsafe
+
+        // This should leave us with 0 dink value, and fail
         cat.bite("gold", me);
     }
 

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -627,6 +627,7 @@ contract BiteTest is DSTest {
 
         // tag=4, mat=2
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
+        cat.file("gold", "chop", ray(1.1 ether));
 
         assertEq(ink("gold", address(this)),  40 ether);
         assertEq(art("gold", address(this)), 100 ether);
@@ -636,31 +637,29 @@ contract BiteTest is DSTest {
         cat.file("gold", "lump", rad(200 ether));  // => bite everything
         assertEq(cat.litter(), 0);
         uint auction = cat.bite("gold", address(this));
-        assertEq(cat.litter(), rad(100 ether));
+        assertEq(cat.litter(), rad(110 ether));
         assertEq(ink("gold", address(this)), 0);
         assertEq(art("gold", address(this)), 0);
         assertEq(vow.sin(now),   rad(100 ether));
         assertEq(gem("gold", address(this)), 960 ether);
 
         assertEq(vat.balanceOf(address(vow)),    0 ether);
-        flip.tend(auction, 40 ether,   rad(1 ether));
-        assertEq(cat.litter(), rad(100 ether));
-        flip.tend(auction, 40 ether, rad(100 ether));
-        assertEq(cat.litter(), rad(100 ether));
-
-        assertEq(vat.balanceOf(address(this)),   0 ether);
-        assertEq(gem("gold", address(this)),   960 ether);
         vat.mint(address(this), 100 ether);  // magic up some dai for bidding
-        flip.dent(auction, 38 ether,  rad(100 ether));
-        assertEq(cat.litter(), rad(100 ether));
-        assertEq(vat.balanceOf(address(this)), 100 ether);
+        flip.tend(auction, 40 ether,   rad(1 ether));
+        flip.tend(auction, 40 ether, rad(110 ether));
+
+        assertEq(vat.balanceOf(address(this)),  90 ether);
+        assertEq(gem("gold", address(this)),   960 ether);
+        flip.dent(auction, 38 ether,  rad(110 ether));
+        assertEq(vat.balanceOf(address(this)),  90 ether);
         assertEq(gem("gold", address(this)),   962 ether);
         assertEq(vow.sin(now),     rad(100 ether));
 
         hevm.warp(now + 4 hours);
+        assertEq(cat.litter(), rad(110 ether));
         flip.deal(auction);
         assertEq(cat.litter(), 0);
-        assertEq(vat.balanceOf(address(vow)),  100 ether);
+        assertEq(vat.balanceOf(address(vow)),  110 ether);
     }
 
     // tests a partial lot liquidation because it would fill the literbox
@@ -672,6 +671,7 @@ contract BiteTest is DSTest {
 
         // tag=4, mat=2
         vat.file("gold", 'spot', ray(1 ether));  // now unsafe
+        // cat.file("gold", "chop", ray(1.1 ether));
 
         assertEq(ink("gold", address(this)), 100 ether);
         assertEq(art("gold", address(this)), 150 ether);
@@ -683,7 +683,9 @@ contract BiteTest is DSTest {
         assertEq(cat.box(), rad(75 ether));
         assertEq(cat.litter(), 0);
         uint auction = cat.bite("gold", address(this));
-        assertEq(cat.litter(), rad(75 ether));
+        // (,,,,,,,uint tab) = flip.bids(auction);
+        // assertTrue(rad(75 ether) - cat.litter() < ray(3 ether));
+        // assertEq(cat.litter(), tab);
         assertEq(ink("gold", address(this)), 50 ether);
         assertEq(art("gold", address(this)), 75 ether);
         assertEq(vow.sin(now), rad(75 ether));

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -527,26 +527,26 @@ contract BiteTest is DSTest {
         me = address(this);
     }
 
-    function test_set_lump_multiple_ilks() public {
-        cat.file("gold",   "lump", rad(115792 ether));
+    function test_set_dunk_multiple_ilks() public {
+        cat.file("gold",   "dunk", rad(115792 ether));
         (,, uint256 goldLump) = cat.ilks("gold");
         assertEq(goldLump, rad(115792 ether));
-        cat.file("silver", "lump", rad(115792 ether));
+        cat.file("silver", "dunk", rad(115792 ether));
         (,, uint256 silverLump) = cat.ilks("silver");
         assertEq(silverLump, rad(115792 ether));
     }
-    function testFail_lump_too_large() public {
+    function testFail_dunk_too_large() public {
         // 115792.089237316195423570985008687907853269984665640 * RAD + 1
-        cat.file("gold", "lump", uint256(-1) / 10 ** 27 + 1);
+        cat.file("gold", "dunk", uint256(-1) / 10 ** 27 + 1);
     }
     function test_cat_set_box() public {
         assertEq(cat.box(), rad((10 ether) * MLN));
         cat.file("box", rad((20 ether) * MLN));
         assertEq(cat.box(), rad((20 ether) * MLN));
     }
-    function test_bite_max_lump() public {
+    function test_bite_max_dunk() public {
         uint256 MAX_LUMP = uint256(-1) / 10 ** 27;
-        cat.file("gold", "lump", MAX_LUMP);
+        cat.file("gold", "dunk", MAX_LUMP);
         cat.file("box", uint256(-1));
 
         vat.file("Line", rad(300000 ether));
@@ -560,7 +560,7 @@ contract BiteTest is DSTest {
         (,,,,,,, uint256 tab) = flip.bids(auction);
         assertEq(tab, MAX_LUMP / 10 ** 27 * 10 ** 27);
     }
-    function testFail_bite_forced_over_max_lump() public {
+    function testFail_bite_forced_over_max_dunk() public {
         uint256 MAX_LUMP = uint256(-1) / 10 ** 27;
         hevm.store(
             address(cat),
@@ -578,13 +578,13 @@ contract BiteTest is DSTest {
 
         cat.bite("gold", address(this));
     }
-    function test_bite_under_lump() public {
+    function test_bite_under_dunk() public {
         vat.file("gold", 'spot', ray(2.5 ether));
         vat.frob("gold", me, me, me, 40 ether, 100 ether);
         // tag=4, mat=2
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
 
-        cat.file("gold", "lump", rad(111 ether));
+        cat.file("gold", "dunk", rad(111 ether));
         cat.file("gold", "chop", ray(1.1 ether));
 
         uint auction = cat.bite("gold", address(this));
@@ -598,14 +598,14 @@ contract BiteTest is DSTest {
         assertEq(lot,        40 ether);
         assertEq(tab,   rad(110 ether));
     }
-    function test_bite_over_lump() public {
+    function test_bite_over_dunk() public {
         vat.file("gold", 'spot', ray(2.5 ether));
         vat.frob("gold", me, me, me, 40 ether, 100 ether);
         // tag=4, mat=2
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
 
         cat.file("gold", "chop", ray(1.1 ether));
-        cat.file("gold", "lump", rad(82.5 ether));
+        cat.file("gold", "dunk", rad(82.5 ether));
 
         uint auction = cat.bite("gold", address(this));
         // the CDP is partially liquidated
@@ -634,7 +634,7 @@ contract BiteTest is DSTest {
         assertEq(vow.Woe(), 0 ether);
         assertEq(gem("gold", address(this)), 960 ether);
 
-        cat.file("gold", "lump", rad(200 ether));  // => bite everything
+        cat.file("gold", "dunk", rad(200 ether));  // => bite everything
         assertEq(cat.litter(), 0);
         uint auction = cat.bite("gold", address(this));
         assertEq(cat.litter(), rad(110 ether));
@@ -679,7 +679,7 @@ contract BiteTest is DSTest {
         assertEq(gem("gold", address(this)), 900 ether);
 
         cat.file("box", rad(75 ether));
-        cat.file("gold", "lump", rad(100 ether));
+        cat.file("gold", "dunk", rad(100 ether));
         assertEq(cat.box(), rad(75 ether));
         assertEq(cat.litter(), 0);
         uint auction = cat.bite("gold", address(this));
@@ -730,7 +730,7 @@ contract BiteTest is DSTest {
         assertEq(gem("gold", address(this)), 900 ether);
 
         cat.file("box", rad(75 ether));
-        cat.file("gold", "lump", rad(100 ether));
+        cat.file("gold", "dunk", rad(100 ether));
         assertEq(cat.box(), rad(75 ether));
         assertEq(cat.litter(), 0);
         cat.bite("gold", address(this));
@@ -760,7 +760,7 @@ contract BiteTest is DSTest {
         assertEq(gem("gold", address(this)), 900 ether);
 
         cat.file("box", rad(75 ether));
-        cat.file("gold", "lump", rad(100 ether));
+        cat.file("gold", "dunk", rad(100 ether));
         assertEq(cat.box(), rad(75 ether));
         assertEq(cat.litter(), 0);
         uint auction = cat.bite("gold", address(this));
@@ -832,7 +832,7 @@ contract BiteTest is DSTest {
         vat.frob("gold", me, me, me, 40 ether, 100 ether);
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
 
-        cat.file("gold", "lump", rad(200 ether));  // => bite everything
+        cat.file("gold", "dunk", rad(200 ether));  // => bite everything
         assertEq(vow.sin(now), rad(  0 ether));
         cat.bite("gold", address(this));
         assertEq(vow.sin(now), rad(100 ether));


### PR DESCRIPTION
- [x] change meme names
- [x] prevent dusty Vault remainders (won't fix)
- [x] prevent dusty auctions
- [x] consider @rainbreak's arguments against including `chop` in the `litterbox`: https://github.com/makerdao/dss/pull/123#pullrequestreview-466283864
- [x] chop becomes a wad?
- [x] more tests
  - [x] make sure liquidation space left in litterbox is not dusty
  - [x] that we prevent Vaults from being left dusty (won't fix)
  - [x] change all chop tests from ray to wad?
  - [x] `chop` should be set to something non-zero and tests adjusted accordingly

This PR contains further improvements on: https://github.com/makerdao/dss/pull/123