### PR TITLE
null auctions tests + fix

### DIFF
--- a/src/cat.sol
+++ b/src/cat.sol
@@ -152,6 +152,7 @@ contract Cat is LibNote {
 
             dart = min(art, mul(min(milk.dunk, room), RAY) / rate / milk.chop);
         }
+        require(dart > 0, "Cat/null-auction");
 
         uint256 dink = min(ink, mul(ink, dart) / art);
 


### PR DESCRIPTION
Tests for the null auction issue. The dusty auction check protects us unless there are seriously pathological values (e.g. tiny `dust` or huge `rate` or `chop`). I added a require statement for the ultra-edges, but maybe it isn't strictly needed in practice.