### PR TITLE
No chop in litter

### DIFF
--- a/src/cat.sol
+++ b/src/cat.sol
@@ -20,7 +20,7 @@ pragma solidity >=0.5.12;
 import "./lib.sol";
 
 interface Kicker {
-    function kick(address urn, address gal, uint256 tab, uint256 lot, uint256 bid, uint256 bar)
+    function kick(address urn, address gal, uint256 tab, uint256 lot, uint256 bid)
         external returns (uint256);
 }
 
@@ -69,6 +69,8 @@ contract Cat is LibNote {
     VowLike public vow;    // Debt Engine
     uint256 public box;    // Max Dai out for liquidation        [rad]
     uint256 public litter; // Balance of Dai out for liquidation [rad]
+
+    mapping (address => mapping (uint256 => uint256)) public tabs;  // per-contract per-auction dai to recapitalize [rad]
 
     // --- Events ---
     event Bite(
@@ -177,15 +179,16 @@ contract Cat is LibNote {
                 gal: address(vow),
                 tab: rmul(tab, milk.chop),
                 lot: dink,
-                bid: 0,
-                bar: tab
+                bid: 0
             });
+            tabs[milk.flip][id] = tab;
             emit Bite(ilk, urn, dink, dart, tab, milk.flip, id);
         }
     }
 
-    function claw(uint256 rad) external note auth {
-        litter = sub(litter, rad);
+    function claw(uint256 id) external note auth {
+        litter = sub(litter, tabs[msg.sender][id]);
+        tabs[msg.sender][id] = 0;
     }
 
     function cage() external note auth {

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -188,7 +188,7 @@ contract Cat is LibNote {
 
     function claw(uint256 id) external note auth {
         litter = sub(litter, tabs[msg.sender][id]);
-        tabs[msg.sender][id] = 0;
+        delete tabs[msg.sender][id];
     }
 
     function cage() external note auth {

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -61,7 +61,8 @@ contract Flipper is LibNote {
         uint48  end;  // auction expiry time      [unix epoch time]
         address usr;
         address gal;
-        uint256 tab;  // total dai wanted         [rad]
+        uint256 tab;  // total dai wanted          [rad]
+        uint256 bar;  // dai needed to cancel debt [rad]
     }
 
     mapping (uint256 => Bid) public bids;
@@ -115,7 +116,7 @@ contract Flipper is LibNote {
     }
 
     // --- Auction ---
-    function kick(address usr, address gal, uint256 tab, uint256 lot, uint256 bid)
+    function kick(address usr, address gal, uint256 tab, uint256 lot, uint256 bid, uint256 bar)
         public auth returns (uint256 id)
     {
         require(kicks < uint256(-1), "Flipper/overflow");
@@ -128,6 +129,7 @@ contract Flipper is LibNote {
         bids[id].usr = usr;
         bids[id].gal = gal;
         bids[id].tab = tab;
+        bids[id].bar = bar;
 
         vat.flux(ilk, msg.sender, address(this), lot);
 
@@ -178,7 +180,7 @@ contract Flipper is LibNote {
     }
     function deal(uint256 id) external note {
         require(bids[id].tic != 0 && (bids[id].tic < now || bids[id].end < now), "Flipper/not-finished");
-        cat.claw(bids[id].tab);
+        cat.claw(bids[id].bar);
         vat.flux(ilk, address(this), bids[id].guy, bids[id].lot);
         delete bids[id];
     }

--- a/src/flip.sol
+++ b/src/flip.sol
@@ -61,8 +61,7 @@ contract Flipper is LibNote {
         uint48  end;  // auction expiry time      [unix epoch time]
         address usr;
         address gal;
-        uint256 tab;  // total dai wanted          [rad]
-        uint256 bar;  // dai needed to cancel debt [rad]
+        uint256 tab;  // total dai wanted         [rad]
     }
 
     mapping (uint256 => Bid) public bids;
@@ -116,7 +115,7 @@ contract Flipper is LibNote {
     }
 
     // --- Auction ---
-    function kick(address usr, address gal, uint256 tab, uint256 lot, uint256 bid, uint256 bar)
+    function kick(address usr, address gal, uint256 tab, uint256 lot, uint256 bid)
         public auth returns (uint256 id)
     {
         require(kicks < uint256(-1), "Flipper/overflow");
@@ -129,7 +128,6 @@ contract Flipper is LibNote {
         bids[id].usr = usr;
         bids[id].gal = gal;
         bids[id].tab = tab;
-        bids[id].bar = bar;
 
         vat.flux(ilk, msg.sender, address(this), lot);
 
@@ -180,7 +178,7 @@ contract Flipper is LibNote {
     }
     function deal(uint256 id) external note {
         require(bids[id].tic != 0 && (bids[id].tic < now || bids[id].end < now), "Flipper/not-finished");
-        cat.claw(bids[id].bar);
+        cat.claw(id);
         vat.flux(ilk, address(this), bids[id].guy, bids[id].lot);
         delete bids[id];
     }
@@ -188,7 +186,7 @@ contract Flipper is LibNote {
     function yank(uint256 id) external note auth {
         require(bids[id].guy != address(0), "Flipper/guy-not-set");
         require(bids[id].bid < bids[id].tab, "Flipper/already-dent-phase");
-        cat.claw(bids[id].tab);
+        cat.claw(id);
         vat.flux(ilk, address(this), msg.sender, bids[id].lot);
         vat.move(msg.sender, bids[id].guy, bids[id].bid);
         delete bids[id];

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -424,7 +424,7 @@ contract EndTest is DSTest {
         // get 1 dai from ali
         ali.move(address(ali), address(this), rad(1 ether));
         vat.hope(address(gold.flip));
-        (,uint lot,,,,,,) = gold.flip.bids(auction);
+        (,uint lot,,,,,,,) = gold.flip.bids(auction);
         gold.flip.tend(auction, lot, rad(1 ether)); // bid 1 dai
         assertEq(dai(urn1), 14 ether);
 

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -424,7 +424,7 @@ contract EndTest is DSTest {
         // get 1 dai from ali
         ali.move(address(ali), address(this), rad(1 ether));
         vat.hope(address(gold.flip));
-        (,uint lot,,,,,,,) = gold.flip.bids(auction);
+        (,uint lot,,,,,,) = gold.flip.bids(auction);
         gold.flip.tend(auction, lot, rad(1 ether)); // bid 1 dai
         assertEq(dai(urn1), 14 ether);
 

--- a/src/test/flip.t.sol
+++ b/src/test/flip.t.sol
@@ -137,6 +137,7 @@ contract FlipTest is DSTest {
                   , usr: usr
                   , gal: gal
                   , bid: 0
+                  , bar: 50 ether
                   });
     }
     function testFail_tend_empty() public {
@@ -149,6 +150,7 @@ contract FlipTest is DSTest {
                             , usr: usr
                             , gal: gal
                             , bid: 0
+                            , bar: 50 ether
                             });
 
         Guy(ali).tend(id, 100 ether, 1 ether);
@@ -176,6 +178,7 @@ contract FlipTest is DSTest {
                             , usr: usr
                             , gal: gal
                             , bid: 0
+                            , bar: 50 ether
                             });
         hevm.warp(now + 5 hours);
 
@@ -191,6 +194,7 @@ contract FlipTest is DSTest {
                             , usr: usr
                             , gal: gal
                             , bid: 0
+                            , bar: 50 ether
                             });
         Guy(ali).tend(id, 100 ether,  1 ether);
         Guy(bob).tend(id, 100 ether, 50 ether);
@@ -207,6 +211,7 @@ contract FlipTest is DSTest {
                             , usr: usr
                             , gal: gal
                             , bid: 0
+                            , bar: 200 ether
                             });
 
         assertEq(vat.dai_balance(ali), 200 ether);
@@ -222,6 +227,7 @@ contract FlipTest is DSTest {
                             , usr: usr
                             , gal: gal
                             , bid: 0
+                            , bar: 50 ether
                             });
         assertTrue( Guy(ali).try_tend(id, 100 ether, 1.00 ether));
         assertTrue(!Guy(bob).try_tend(id, 100 ether, 1.01 ether));
@@ -243,6 +249,7 @@ contract FlipTest is DSTest {
                             , usr: usr
                             , gal: gal
                             , bid: 0
+                            , bar: 50 ether
                             });
 
         // only after ttl
@@ -256,6 +263,7 @@ contract FlipTest is DSTest {
                             , usr: usr
                             , gal: gal
                             , bid: 0
+                            , bar: 50 ether
                             });
 
         // or after end
@@ -272,6 +280,7 @@ contract FlipTest is DSTest {
                             , usr: usr
                             , gal: gal
                             , bid: 0
+                            , bar: 50 ether
                             });
         // check no tick
         assertTrue(!Guy(ali).try_tick(id));
@@ -291,6 +300,7 @@ contract FlipTest is DSTest {
                             , usr: usr
                             , gal: gal
                             , bid: 0
+                            , bar: 50 ether
                             });
         assertTrue(!Guy(ali).try_deal(id));
         hevm.warp(now + 2 weeks);
@@ -304,6 +314,7 @@ contract FlipTest is DSTest {
                             , usr: usr
                             , gal: gal
                             , bid: 0
+                            , bar: rad(50 ether)
                             });
 
         Guy(ali).tend(id, 100 ether, 1 ether);
@@ -334,6 +345,7 @@ contract FlipTest is DSTest {
                             , usr: usr
                             , gal: gal
                             , bid: 0
+                            , bar: 50 ether
                             });
 
         // we have some amount of litter in the box

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -400,29 +400,6 @@ contract JoinTest is DSTest {
     }
 }
 
-interface FlipLike {
-    struct Bid {
-        uint256 bid;
-        uint256 lot;
-        address guy;  // high bidder
-        uint48  tic;  // expiry time
-        uint48  end;
-        address urn;
-        address gal;
-        uint256 tab;
-    }
-    function bids(uint) external view returns (
-        uint256 bid,
-        uint256 lot,
-        address guy,
-        uint48  tic,
-        uint48  end,
-        address usr,
-        address gal,
-        uint256 tab
-    );
-}
-
 contract BiteTest is DSTest {
     Hevm hevm;
 
@@ -557,25 +534,28 @@ contract BiteTest is DSTest {
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
 
         uint256 auction = cat.bite("gold", address(this));
-        (,,,,,,, uint256 tab) = flip.bids(auction);
+        (,,,,,,, uint256 tab,) = flip.bids(auction);
         assertEq(tab, MAX_LUMP / 10 ** 27 * 10 ** 27);
     }
     function testFail_bite_forced_over_max_dunk() public {
-        uint256 MAX_LUMP = uint256(-1) / 10 ** 27;
+        uint256 MAX_DUNK = uint256(-1) / 10 ** 27;
         hevm.store(
             address(cat),
             bytes32(uint256(keccak256(abi.encode(bytes32("gold"), uint256(1)))) + 2),
-            bytes32(MAX_LUMP + 1)
+            // since rate is at least 10^27, this is the smallest meaningful
+            // increment for dunk
+            bytes32(MAX_DUNK + 10 ** 27)
         );
         cat.file("box", uint256(-1));
 
-        vat.file("Line", rad(300000 ether));
-        vat.file("gold", "line", rad(300000 ether));
-        vat.file("gold", 'spot', ray(205 ether));
-        vat.frob("gold", me, me, me, 1000 ether, 200000 ether);
+        vat.file("Line", uint256(-1));
+        vat.file("gold", "line", uint256(-1));
+        vat.file("gold", "spot", ray(1000000 ether));
+        vat.frob("gold", me, me, me, 1000 ether, int256(2 * MAX_DUNK / 10 ** 27));
 
-        vat.file("gold", 'spot', ray(2 ether));  // now unsafe
+        vat.file("gold", "spot", ray(2 ether));  // now unsafe
 
+        cat.file("gold", "chop", ray(1 ether));
         cat.bite("gold", address(this));
     }
     function test_bite_under_dunk() public {
@@ -594,7 +574,7 @@ contract BiteTest is DSTest {
         // all debt goes to the vow
         assertEq(vow.Awe(), rad(100 ether));
         // auction is for all collateral
-        (, uint lot,,,,,, uint tab) = flip.bids(auction);
+        (, uint lot,,,,,, uint tab,) = flip.bids(auction);
         assertEq(lot,        40 ether);
         assertEq(tab,   rad(110 ether));
     }
@@ -608,15 +588,19 @@ contract BiteTest is DSTest {
         cat.file("gold", "dunk", rad(82.5 ether));
 
         uint auction = cat.bite("gold", address(this));
+
         // the CDP is partially liquidated
-        assertEq(ink("gold", address(this)), 10 ether);
-        assertEq(art("gold", address(this)), 25 ether);
+        assertEq(ink("gold", address(this)),  7   ether);
+        assertEq(art("gold", address(this)), 17.5 ether);
+
         // a fraction of the debt goes to the vow
-        assertEq(vow.Awe(), rad(75 ether));
+        assertEq(vow.Awe(), rad(82.5 ether));
+
         // auction is for a fraction of the collateral
-        (, uint lot,,,,,, uint tab) = FlipLike(address(flip)).bids(auction);
-        assertEq(lot,       30 ether);
-        assertEq(tab,   rad(82.5 ether));
+        (, uint lot,,,,,, uint tab, uint bar) = flip.bids(auction);
+        assertEq(lot,     33    ether);
+        assertEq(tab, rad(90.75 ether));
+        assertEq(bar, rad(82.5  ether));
     }
 
     function test_happy_bite() public {
@@ -637,7 +621,7 @@ contract BiteTest is DSTest {
         cat.file("gold", "dunk", rad(200 ether));  // => bite everything
         assertEq(cat.litter(), 0);
         uint auction = cat.bite("gold", address(this));
-        assertEq(cat.litter(), rad(110 ether));
+        assertEq(cat.litter(), rad(100 ether));
         assertEq(ink("gold", address(this)), 0);
         assertEq(art("gold", address(this)), 0);
         assertEq(vow.sin(now),   rad(100 ether));
@@ -656,7 +640,7 @@ contract BiteTest is DSTest {
         assertEq(vow.sin(now),     rad(100 ether));
 
         hevm.warp(now + 4 hours);
-        assertEq(cat.litter(), rad(110 ether));
+        assertEq(cat.litter(), rad(100 ether));
         flip.deal(auction);
         assertEq(cat.litter(), 0);
         assertEq(vat.balanceOf(address(vow)),  110 ether);

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -534,7 +534,7 @@ contract BiteTest is DSTest {
         vat.file("gold", 'spot', ray(2 ether));  // now unsafe
 
         uint256 auction = cat.bite("gold", address(this));
-        (,,,,,,, uint256 tab,) = flip.bids(auction);
+        (,,,,,,, uint256 tab) = flip.bids(auction);
         assertEq(tab, MAX_LUMP / 10 ** 27 * 10 ** 27);
     }
     function testFail_bite_forced_over_max_dunk() public {
@@ -574,7 +574,7 @@ contract BiteTest is DSTest {
         // all debt goes to the vow
         assertEq(vow.Awe(), rad(100 ether));
         // auction is for all collateral
-        (, uint lot,,,,,, uint tab,) = flip.bids(auction);
+        (, uint lot,,,,,, uint tab) = flip.bids(auction);
         assertEq(lot,        40 ether);
         assertEq(tab,   rad(110 ether));
     }
@@ -597,10 +597,11 @@ contract BiteTest is DSTest {
         assertEq(vow.Awe(), rad(82.5 ether));
 
         // auction is for a fraction of the collateral
-        (, uint lot,,,,,, uint tab, uint bar) = flip.bids(auction);
+        (, uint lot,,,,,, uint tab) = flip.bids(auction);
         assertEq(lot,     33    ether);
         assertEq(tab, rad(90.75 ether));
-        assertEq(bar, rad(82.5  ether));
+
+        assertEq(cat.tabs(address(flip), auction), rad(82.5  ether));
     }
 
     function test_happy_bite() public {


### PR DESCRIPTION
Motivation for this change:
 - more natural: we want to make sure there's enough liquidity to prevent bad debt accumulation, so it makes sense to directly set a limit on the on-auction sin rather than the sin+penalty
 - easier to reason about: governance doesn't have to consider the liquidation penalty when setting `box`
 - simplifies the Cat: not having to account for `chop` when enforcing the on-auction debt limit streamlines the calculations, leaving less opportunity for bugs and minimizing rounding error (not sure if there's a net gas savings...probably not, due to using more storage); it also makes the code more maintainable

There were a lot of options for where to store the original `tab` without penalty values. I decided to store them in the Cat because this avoids changes to the Flipper's public APIs and maintains separation of concerns better (the Flipper only cares about auctioning collateral, and the Cat just relies on monotonically increasing ids from each Flipper and a call to `claw` upon auction termination). The mapping that stores them uses the Flipper address instead of `ilk` for indexing because upgrades might introduce multiple Flippers with overlapping auction index ranges for the same collateral type (secondarily, it cuts down on parameter passing as we can take advantage of `msg.sender` for the first index).