### PR TITLE
SC-5246-null-dink: catch null dink

### DIFF
--- a/src/cat.sol
+++ b/src/cat.sol
@@ -148,8 +148,8 @@ contract Cat is LibNote {
 
         uint256 dink = min(ink, mul(ink, dart) / art);
 
-        require(dart > 0 && dink > 0, "Cat/null-auction");
-        require(dink <= 2**255 && dart <= 2**255, "Cat/overflow");
+        require(dart >  0      && dink >  0     , "Cat/null-auction");
+        require(dart <= 2**255 && dink <= 2**255, "Cat/overflow"    );
 
         // This may leave the CDP in a dusty state
         vat.grab(

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -148,9 +148,7 @@ contract Cat is LibNote {
 
         uint256 dink = min(ink, mul(ink, dart) / art);
 
-        // TODO(cmooney): collapse these null errors into 1 require
-        require(dart > 0, "Cat/art-null-auction");
-        require(dink > 0, "Cat/ilk-null-auction");
+        require(dart > 0 && dink > 0, "Cat/null-auction");
         require(dink <= 2**255 && dart <= 2**255, "Cat/overflow");
 
         // This may leave the CDP in a dusty state

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -145,10 +145,12 @@ contract Cat is LibNote {
 
             dart = min(art, mul(min(milk.dunk, room), WAD) / rate / milk.chop);
         }
-        require(dart > 0, "Cat/null-auction");
 
         uint256 dink = min(ink, mul(ink, dart) / art);
 
+        // TODO(cmooney): collapse these null errors into 1 require
+        require(dart > 0, "Cat/art-null-auction");
+        require(dink > 0, "Cat/ilk-null-auction");
         require(dink <= 2**255 && dart <= 2**255, "Cat/overflow");
 
         // This may leave the CDP in a dusty state

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -856,6 +856,23 @@ contract BiteTest is DSTest {
         cat.bite("gold", me);
     }
 
+    function testFail_null_auctions_dink_artificial_values_2() public {
+        vat.file("gold", "spot", ray(2000 ether));
+        vat.file("gold", "line", rad(20000 ether));
+        vat.file("Line",         rad(20000 ether));
+        vat.frob("gold", me, me, me, 10 ether, 15000 ether);
+
+        cat.file("box", rad(1000000 ether));  // plenty of room
+
+        // misconfigured dunk (e.g. precision factor incorrect in spell)
+        cat.file("gold", "dunk", rad(100));
+
+        vat.file("gold", 'spot', ray(1000 ether));  // now unsafe
+
+        // This should leave us with 0 dink value, and fail
+        cat.bite("gold", me);
+    }
+
     function testFail_null_spot_value() public {
         // spot = tag / (par . mat)
         // tag=5, mat=2

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -789,7 +789,7 @@ contract BiteTest is DSTest {
         assertEq(vat.balanceOf(address(vow)),  150 ether);
     }
 
-    function testFail_null_auctions_art_realistic_values() public {
+    function testFail_null_auctions_dart_realistic_values() public {
         vat.file("gold", "dust", rad(100 ether));
         vat.file("gold", "spot", ray(2.5 ether));
         vat.file("gold", "line", rad(2000 ether));
@@ -817,7 +817,7 @@ contract BiteTest is DSTest {
         cat.bite("gold", me);
     }
 
-    function testFail_null_auctions_art_artificial_values() public {
+    function testFail_null_auctions_dart_artificial_values() public {
         // artificially tiny dust value, e.g. due to misconfiguration
         vat.file("dust", "dust", 1);
         vat.file("gold", "spot", ray(2.5 ether));
@@ -844,7 +844,7 @@ contract BiteTest is DSTest {
         cat.bite("gold", me);
     }
 
-    function testFail_null_auctions_ilk_artificial_values() public {
+    function testFail_null_auctions_dink_artificial_values() public {
         // we're going to make 1 wei of ink worth 250
         vat.file("gold", "spot", ray(250 ether) * 1 ether);
         cat.file("gold", "dunk", rad(50 ether));

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -789,7 +789,7 @@ contract BiteTest is DSTest {
         assertEq(vat.balanceOf(address(vow)),  150 ether);
     }
 
-    function testFail_null_auctions_realistic_values() public {
+    function testFail_null_auctions_art_realistic_values() public {
         vat.file("gold", "dust", rad(100 ether));
         vat.file("gold", "spot", ray(2.5 ether));
         vat.file("gold", "line", rad(2000 ether));
@@ -817,7 +817,7 @@ contract BiteTest is DSTest {
         cat.bite("gold", me);
     }
 
-    function testFail_null_auctions_artificial_values() public {
+    function testFail_null_auctions_art_artificial_values() public {
         // artificially tiny dust value, e.g. due to misconfiguration
         vat.file("dust", "dust", 1);
         vat.file("gold", "spot", ray(2.5 ether));
@@ -841,6 +841,18 @@ contract BiteTest is DSTest {
         // so this should revert and not create a null auction.
         // The dustiness check on room doesn't apply here, so additional
         // logic is needed to make this test pass.
+        cat.bite("gold", me);
+    }
+
+    function testFail_null_auctions_ilk_artificial_values() public {
+        // we're going to make 1 wei of ink worth 250
+        vat.file("gold", "spot", ray(250 ether) * 1 ether);
+        cat.file("gold", "dunk", rad(50 ether));
+        vat.frob("gold", me, me, me, 1, 100 ether);
+
+        vat.file("gold", 'spot', 1);  // massive price crash, now unsafe
+
+        // This should leave us with 0 dink value, and fail
         cat.bite("gold", me);
     }
 


### PR DESCRIPTION
This is a contrived example where we end up with a null `dink`.  Since the system can get in this state, we should probably guard against it.  We might want a more real-world example test too.

We should also think through the implications of not being able to liquidate `1 wei` of collateral.