### PR TITLE
View only scratch function to expose liquidation penalty

### DIFF
--- a/src/cat.sol
+++ b/src/cat.sol
@@ -160,7 +160,7 @@ contract Cat is LibNote {
         { // Avoid stack too deep
             // This calcuation will overflow if dart*rate exceeds ~10^14,
             // i.e. the maximum dunk is roughly 100 trillion DAI.
-            uint256 tab = mul(mul(dart, rate), milk.chop) / WAD;
+            uint256 tab = scratch(ilk,dart);
             litter = add(litter, tab);
 
             id = Kicker(milk.flip).kick({
@@ -181,5 +181,12 @@ contract Cat is LibNote {
 
     function cage() external note auth {
         live = 0;
+    }
+
+    // returns the tab amount for a given dart
+    function scratch(bytes32 ilk, uint dart) public view returns(uint tab){
+        (,uint256 rate,,,) = vat.ilks(ilk);
+        Ilk memory milk = ilks[ilk];
+        tab = mul(mul(dart, rate), milk.chop) / WAD;
     }
 }


### PR DESCRIPTION
I would kindly ask that the cat would expose the tab calculation as a public function.
A similar function exists in compound as an API (in their smart contract).

The motivation is that we are working on an opt-in liquidation system that needs to read the liquidation penalty value from makerdao’s `cat`.
We plan to read the cat address from the `end` contract, but changes like in this version, where the `chop` resolution changed from `rad` to `wad` will break our system (in the future, it is still not deployed).
Hence, a function that for a given `art` returns the tab, would really help.