### PR TITLE
fix: Remove redundant now in flog test

### DIFF
--- a/src/test/vow.t.sol
+++ b/src/test/vow.t.sol
@@ -133,7 +133,7 @@ contract VowTest is DSTest {
         uint tic = now;
         vow.fess(100 ether);
         assertTrue(!try_flog(tic) );
-        hevm.warp(now + tic + 100 seconds);
+        hevm.warp(tic + 100 seconds);
         assertTrue( try_flog(tic) );
     }
 

--- a/src/test/vow.t.sol
+++ b/src/test/vow.t.sol
@@ -130,11 +130,12 @@ contract VowTest is DSTest {
         vow.file('wait', uint(100 seconds));
         assertEq(vow.wait(), 100 seconds);
 
-        uint tic = now;
-        vow.fess(100 ether);
-        assertTrue(!try_flog(tic) );
-        hevm.warp(tic + 100 seconds);
-        assertTrue( try_flog(tic) );
+        uint tic = now;                                                                                                                                                       
+        vow.fess(100 ether);                                                     
+        hevm.warp(tic + 99 seconds);                                             
+        assertTrue(!try_flog(tic) );                                             
+        hevm.warp(tic + 100 seconds);                                            
+        assertTrue( try_flog(tic) ); 
     }
 
     function test_no_reflop() public {


### PR DESCRIPTION
In `wait` test for `flog` the `hevm.warp()` call was warping to `now + tic + 100` when it should have just been `tic + 100`.