### PR TITLE
Preliminary Circuit Breaker

### DIFF
--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -623,4 +623,51 @@ contract DutchClipperTest is DSTest {
         uint256 lotReturn = 30 ether - (rad(60 ether) / ray(4 ether));       // lot - loaf.tab / max = 15
         assertEq(vat.gem(ilk, me), 960 ether + lotReturn);                   // Collateral returned (10 WAD)
     } 
+
+    function test_stop() public {
+        clip.stop();
+    }
+
+    function testFail_stop() public {
+        clip.stop();
+        clip.stop();
+    }
+
+    function test_start() public {
+        clip.stop();
+        clip.start();
+    }
+
+    function testFail_start() public {
+        clip.start();
+    }
+
+    function testFail_stopped_kick() public {
+        uint256 pos;
+        uint256 tab;
+        uint256 lot;
+        address usr;
+        uint96  tic;
+        uint256 top;
+        uint256 ink;
+        uint256 art;
+
+        assertEq(clip.kicks(), 0);
+        (pos, tab, lot, usr, tic, top) = clip.sales(1);
+        assertEq(pos, 0);
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(usr, address(0));
+        assertEq(uint256(tic), 0);
+        assertEq(top, 0);
+        assertEq(vat.gem(ilk, me), 960 ether);
+        (ink, art) = vat.urns(ilk, me);
+        assertEq(ink, 40 ether);
+        assertEq(art, 100 ether);
+
+        clip.stop();
+
+        dog.bark(ilk, me);
+    }
+
 }

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -624,22 +624,9 @@ contract DutchClipperTest is DSTest {
         assertEq(vat.gem(ilk, me), 960 ether + lotReturn);                   // Collateral returned (10 WAD)
     } 
 
-    function test_stop() public {
-        clip.stop();
-    }
-
-    function testFail_stop() public {
-        clip.stop();
-        clip.stop();
-    }
-
-    function test_start() public {
-        clip.stop();
-        clip.start();
-    }
-
-    function testFail_start() public {
-        clip.start();
+    function test_setBreaker() public {
+        clip.setBreaker(1);
+        assertEq(clip.stopped(), 1);
     }
 
     function testFail_stopped_kick() public {
@@ -665,7 +652,7 @@ contract DutchClipperTest is DSTest {
         assertEq(ink, 40 ether);
         assertEq(art, 100 ether);
 
-        clip.stop();
+        clip.setBreaker(1);
 
         dog.bark(ilk, me);
     }


### PR DESCRIPTION
Added logic to `stop` and `start` the clipper. All major functions are frozen when `stopped == true`. I see this as step 1 of a 2 step process. The circuit breaker just stops all auctions. Then we can add more functionality to `yank` those auctions when `stopped==true`.

I added a couple tests. All tests are passing.