### PR TITLE
hole per ilk

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -30,7 +30,7 @@ interface SpotLike {
 }
 
 interface DogLike {
-    function digs(uint256) external;
+    function digs(bytes32, uint256) external;
 }
 
 interface ClipperCallee {
@@ -255,7 +255,7 @@ contract Clipper {
         vat.move(who, vow, owe);
 
         // Removes Dai out for liquidation from accumulator
-        dog.digs(owe);
+        dog.digs(ilk, owe);
 
         if (sale.lot == 0) {
             _remove(id);

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -137,8 +137,9 @@ contract Dog /* is LibNote */ {
             (,rate, spot,, dust) = vat.ilks(ilk);
             require(spot > 0 && mul(ink, spot) < mul(art, rate), "Dog/not-unsafe");
 
-            // Get the minimum value between the remaining space
-            // in the general Hole and the collateral hole
+            // Get the minimum value between: 
+            // 1) Remaining space in the general Hole 
+            // 2) Remaining space in the collateral hole
             uint256 room = min(sub(Hole, Dirt), sub(milk.hole, milk.dirt));
 
             // Verify there is room and it is not dusty

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -137,9 +137,11 @@ contract Dog /* is LibNote */ {
             (,rate, spot,, dust) = vat.ilks(ilk);
             require(spot > 0 && mul(ink, spot) < mul(art, rate), "Dog/not-unsafe");
 
+            // Get the minimum value between the remaining space
+            // in the general Hole and the collateral hole
             uint256 room = min(sub(Hole, Dirt), sub(milk.hole, milk.dirt));
 
-            // Test whether the remaining space in the Hole is dusty
+            // Verify there is room and it is not dusty
             require(room > 0 && room >= dust, "Dog/liquidation-limit-hit");
 
             dart = min(art, mul(room, WAD) / rate / milk.chop);

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -146,7 +146,6 @@ contract ClipperTest is DSTest {
         me = address(this);
 
         vat = new Vat();
-        vat = vat;
 
         spot = new Spotter(address(vat));
         vat.rely(address(spot));
@@ -503,7 +502,7 @@ contract ClipperTest is DSTest {
 
         (, uint256 rate,,,) = vat.ilks(ilk);
 
-        assertEq(lot, 40 ether * (tab * 1 ether / rate / chop) / 100 ether);
+        assertEq(lot, 40 ether * (tab * WAD / rate / chop) / 100 ether);
         assertEq(tab, rad(75 ether) - ray(0.2 ether)); // 0.2 RAY rounding error
 
         assertEq(_ink(ilk, me), 40 ether - lot);
@@ -530,8 +529,8 @@ contract ClipperTest is DSTest {
 
         (, uint256 rate,,,) = vat.ilks(ilk);
 
-        assertEq(lot, 40 ether * (tab * 1 ether / rate / chop) / 100 ether);
-        assertEq(tab, rad(75 ether) - 0.2 * 10 ** 27); // 2* 10 ** 26 rounding error
+        assertEq(lot, 40 ether * (tab * WAD / rate / chop) / 100 ether);
+        assertEq(tab, rad(75 ether) - ray(0.2 ether)); // 0.2 RAY rounding error
 
         assertEq(_ink(ilk, me), 40 ether - lot);
         assertEq(_art(ilk, me), 100 ether - tab * WAD / rate / chop);

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -7,7 +7,6 @@ import "ds-value/value.sol";
 import {Vat}     from "../vat.sol";
 import {Spotter} from "../spot.sol";
 import {Vow}     from "../vow.sol";
-import {GemJoin} from "../join.sol";
 
 import {Clipper} from "../clip.sol";
 import "../abaci.sol";
@@ -16,33 +15,6 @@ import "../dog.sol";
 interface Hevm {
     function warp(uint256) external;
     function store(address,bytes32,bytes32) external;
-}
-interface PipLike {
-    function peek() external returns (bytes32, bool);
-    function poke(bytes32) external;
-}
-
-contract TestVat is Vat {
-    function mint(address usr, uint256 rad) public {
-        dai[usr] += rad;
-    }
-}
-
-contract TestVow is Vow {
-    constructor(address vat, address flapper, address flopper)
-        public Vow(vat, flapper, flopper) {}
-    // Total deficit
-    function Awe() public view returns (uint256) {
-        return vat.sin(address(this));
-    }
-    // Total surplus
-    function Joy() public view returns (uint256) {
-        return vat.dai(address(this));
-    }
-    // Unqueued, pre-auction debt
-    function Woe() public view returns (uint256) {
-        return sub(sub(Awe(), Sin), Ash);
-    }
 }
 
 contract Guy {
@@ -78,18 +50,13 @@ contract Guy {
 contract ClipperTest is DSTest {
     Hevm hevm;
 
-    TestVat vat;
+    Vat     vat;
     Dog     dog;
     Spotter spot;
-    TestVow vow;
+    Vow     vow;
     DSValue pip;
 
-    GemJoin gemA;
-
     Clipper clip;
-
-    DSToken gov;
-    DSToken gold;
 
     address me;
 
@@ -169,32 +136,22 @@ contract ClipperTest is DSTest {
 
         me = address(this);
 
-        gov = new DSToken('GOV');
-        gov.mint(100 ether);
-
-        vat = new TestVat();
+        vat = new Vat();
         vat = vat;
 
         spot = new Spotter(address(vat));
         vat.rely(address(spot));
 
-        vow = new TestVow(address(vat), address(0), address(0));
+        vow = new Vow(address(vat), address(0), address(0));
 
         dog = new Dog(address(vat));
         dog.file("vow", address(vow));
         vat.rely(address(dog));
         vow.rely(address(dog));
 
-        gold = new DSToken("GEM");
-        gold.mint(1000 ether);
-
-
         vat.init(ilk);
 
-        gemA = new GemJoin(address(vat), ilk, address(gold));
-        vat.rely(address(gemA));
-        gold.approve(address(gemA));
-        gemA.join(me, 1000 ether);
+        vat.slip(ilk, me, 1000 ether);
 
         pip = new DSValue();
         pip.poke(bytes32(uint256(5 ether))); // Spot = $2.5
@@ -203,8 +160,8 @@ contract ClipperTest is DSTest {
         spot.file(ilk, bytes32("mat"), ray(2 ether)); // 100% liquidation ratio for easier test calcs
         spot.poke(ilk);
 
-        vat.file(ilk, "line", rad(1000 ether));
-        vat.file("Line",         rad(1000 ether));
+        vat.file(ilk, "line", rad(10000 ether));
+        vat.file("Line",      rad(10000 ether));
 
         clip = new Clipper(address(vat), address(spot), address(dog), ilk);
         clip.rely(address(dog));
@@ -215,8 +172,6 @@ contract ClipperTest is DSTest {
         dog.rely(address(clip));
 
         vat.rely(address(clip));
-
-        gold.approve(address(vat));
 
         assertEq(vat.gem(ilk, me), 1000 ether);
         assertEq(vat.dai(me), 0);  
@@ -233,8 +188,8 @@ contract ClipperTest is DSTest {
         Guy(ali).hope(address(clip));
         Guy(bob).hope(address(clip));
 
-        vat.mint(address(ali), rad(1000 ether));
-        vat.mint(address(bob), rad(1000 ether));
+        vat.suck(address(0), address(ali), rad(1000 ether));
+        vat.suck(address(0), address(bob), rad(1000 ether));
     }
 
     function checkExpDecrease(


### PR DESCRIPTION
It doesn't test specifically that digs decrements correctly both dirt values. But wasn't testing that before either.
In order to check this, we need to use the takeSetup modifier, but it would be nice to simplify this modifier to just do the simple set up without any bark call inside it.
I guess this can be done later in another PR.