### PR TITLE
Upgrade dapptools version for CI running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ before_install:
   - echo "trusted-users = root travis" | sudo tee -a /etc/nix/nix.conf && sudo pkill nix-daemon
   - cachix use maker
   - git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
-  - nix-env -f https://github.com/makerdao/makerpkgs/tarball/master -iA dappPkgsVersions.seth-0_8_4.dapp
+  - nix-env -f https://github.com/makerdao/makerpkgs/tarball/master -iA dappPkgsVersions.hevm-0_41_0.dapp
 script:
   - dapp --use solc:0.5.12 test


### PR DESCRIPTION
Not really sure why pinging to the previous version stopped working but pinging to the latest release works.