### PR TITLE
Clipper cleanup

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -89,6 +89,13 @@ contract Clipper {
         address indexed usr
     );
 
+    event Take(
+        uint256  id,
+        uint256 tab,
+        uint256 lot,
+        address indexed   usr
+    );
+
     event Redo(
         uint256  id,
         uint256 tab,
@@ -267,7 +274,7 @@ contract Clipper {
             sales[id].lot = sale.lot;
         }
 
-        // emit event?
+        emit Take(id, sale.tab, sale.lot, sale.usr);
     }
 
     function _remove(uint256 id) internal {

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -89,7 +89,7 @@ contract Clipper {
         address indexed usr
     );
 
-    event Warm(
+    event Redo(
         uint256  id,
         uint256 tab,
         uint256 lot,
@@ -200,7 +200,7 @@ contract Clipper {
         require(has, "Clipper/invalid-price");
         sales[id].top = rmul(rdiv(mul(uint256(val), 10 ** 9), spot.par()), buf);
 
-        emit Warm(id, sales[id].tab, sales[id].lot, sales[id].usr);
+        emit Redo(id, sales[id].tab, sales[id].lot, sales[id].usr);
     }
 
     // Buy amt of collateral from auction indexed by id

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -205,10 +205,10 @@ contract Clipper {
 
     // Buy amt of collateral from auction indexed by id
     function take(uint256 id,           // Auction id
-                  uint256 amt,          // Upper limit on amount of collateral to buy       [wad]
-                  uint256 max,          // maximum acceptable price (DAI / ETH)             [ray]
-                  address who,          // Who will receive the collateral and pay the debt
-                  bytes calldata data   
+                  uint256 amt,          // Upper limit on amount of collateral to buy  [wad]
+                  uint256 max,          // maximum acceptable price (DAI / collateral) [ray]
+                  address who,          // Receiver of collateral, payer of DAI, and external call address
+                  bytes calldata data   // Data to pass in external call; if length 0, no call is done
     ) external lock {
         // Read auction data
         Sale memory sale = sales[id];

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -93,7 +93,7 @@ contract Clipper {
         uint256  id,
         uint256 tab,
         uint256 lot,
-        address indexed   usr
+        address indexed usr
     );
 
     event Redo(
@@ -213,7 +213,7 @@ contract Clipper {
     // Buy amt of collateral from auction indexed by id
     function take(uint256 id,           // Auction id
                   uint256 amt,          // Upper limit on amount of collateral to buy  [wad]
-                  uint256 max,          // maximum acceptable price (DAI / collateral) [ray]
+                  uint256 max,          // Maximum acceptable price (DAI / collateral) [ray]
                   address who,          // Receiver of collateral, payer of DAI, and external call address
                   bytes calldata data   // Data to pass in external call; if length 0, no call is done
     ) external lock {

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -180,7 +180,7 @@ contract Clipper {
     }
 
     // Reset an auction
-    function warm(uint256 id) external {
+    function redo(uint256 id) external {
         // Read auction data
         Sale memory sale = sales[id];
         require(sale.tab > 0, "Clipper/not-running-auction");

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -260,7 +260,6 @@ contract Clipper {
         if (sale.lot == 0) {
             _remove(id);
         } else if (sale.tab == 0) {
-            // Should we return collateral incrementally instead?
             vat.flux(ilk, address(this), sale.usr, sale.lot);
             _remove(id);
         } else {


### PR DESCRIPTION
Does a few things:
 - cleans up comments
 - renames `warm` to `redo`
 - adds a `Take` event (Although...do we really need this? `tend` and `dent` don't have events, and it seems simple enough to just watch the storage slots of active auctions to detect changes.)