### PR TITLE
[draft] make bad debt grace period configurable per-Ilk

### DIFF
--- a/src/cat.sol
+++ b/src/cat.sol
@@ -42,7 +42,7 @@ interface VatLike {
 }
 
 interface VowLike {
-    function fess(uint256) external;
+    function fess(uint256,uint256) external;
 }
 
 contract Cat is LibNote {
@@ -60,6 +60,7 @@ contract Cat is LibNote {
         address flip;  // Liquidator
         uint256 chop;  // Liquidation Penalty  [wad]
         uint256 dunk;  // Liquidation Quantity [rad]
+        uint256 wait;  // Bad debt grace period [seconds]
     }
 
     mapping (bytes32 => Ilk) public ilks;
@@ -116,6 +117,7 @@ contract Cat is LibNote {
     function file(bytes32 ilk, bytes32 what, uint256 data) external note auth {
         if (what == "chop") ilks[ilk].chop = data;
         else if (what == "dunk") ilks[ilk].dunk = data;
+        else if (what == "wait") ilks[ilk].wait = data;
         else revert("Cat/file-unrecognized-param");
     }
     function file(bytes32 ilk, bytes32 what, address flip) external note auth {
@@ -155,7 +157,7 @@ contract Cat is LibNote {
         vat.grab(
             ilk, urn, address(this), address(vow), -int256(dink), -int256(dart)
         );
-        vow.fess(mul(dart, rate));
+        vow.fess(milk.wait, mul(dart, rate));
 
         { // Avoid stack too deep
             // This calcuation will overflow if dart*rate exceeds ~10^14,

--- a/src/cat.sol
+++ b/src/cat.sol
@@ -157,7 +157,7 @@ contract Cat is LibNote {
         vat.grab(
             ilk, urn, address(this), address(vow), -int256(dink), -int256(dart)
         );
-        vow.fess(milk.wait, mul(dart, rate));
+        vow.fess(add(now, milk.wait), mul(dart, rate));
 
         { // Avoid stack too deep
             // This calcuation will overflow if dart*rate exceeds ~10^14,

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -54,11 +54,11 @@ contract Vow is LibNote {
     FlapLike public flapper;   // Surplus Auction House
     FlopLike public flopper;   // Debt Auction House
 
-    mapping (uint256 => uint256) public sin;  // debt queue
+    mapping (uint256 => mapping (uint256 => uint256)) public sin;  // debt queue
+
     uint256 public Sin;   // Queued debt            [rad]
     uint256 public Ash;   // On-auction debt        [rad]
 
-    uint256 public wait;  // Flop delay             [seconds]
     uint256 public dump;  // Flop initial lot size  [wad]
     uint256 public sump;  // Flop fixed bid size    [rad]
 
@@ -109,15 +109,15 @@ contract Vow is LibNote {
     }
 
     // Push to debt-queue
-    function fess(uint tab) external note auth {
-        sin[now] = add(sin[now], tab);
+    function fess(uint wait, uint tab) external note auth {
+        sin[wait][now] = add(sin[wait][now], tab);
         Sin = add(Sin, tab);
     }
     // Pop from debt-queue
-    function flog(uint era) external note {
+    function flog(uint wait, uint era) external note {
         require(add(era, wait) <= now, "Vow/wait-not-finished");
-        Sin = sub(Sin, sin[era]);
-        sin[era] = 0;
+        Sin = sub(Sin, sin[wait][era]);
+        sin[wait][era] = 0;
     }
 
     // Debt settlement

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -54,8 +54,7 @@ contract Vow is LibNote {
     FlapLike public flapper;   // Surplus Auction House
     FlopLike public flopper;   // Debt Auction House
 
-    mapping (uint256 => mapping (uint256 => uint256)) public sin;  // debt queue
-
+    mapping (uint256 => uint256) public sin; // debt queue
     uint256 public Sin;   // Queued debt            [rad]
     uint256 public Ash;   // On-auction debt        [rad]
 
@@ -109,15 +108,15 @@ contract Vow is LibNote {
     }
 
     // Push to debt-queue
-    function fess(uint wait, uint tab) external note auth {
-        sin[wait][now] = add(sin[wait][now], tab);
+    function fess(uint era, uint tab) external note auth {
+        sin[era] = add(sin[era], tab);
         Sin = add(Sin, tab);
     }
     // Pop from debt-queue
     function flog(uint wait, uint era) external note {
-        require(add(era, wait) <= now, "Vow/wait-not-finished");
-        Sin = sub(Sin, sin[wait][era]);
-        sin[wait][era] = 0;
+        require(era <= now, "Vow/wait-not-finished");
+        Sin = sub(Sin, sin[era]);
+        sin[era] = 0;
     }
 
     // Debt settlement

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -113,7 +113,7 @@ contract Vow is LibNote {
         Sin = add(Sin, tab);
     }
     // Pop from debt-queue
-    function flog(uint wait, uint era) external note {
+    function flog(uint era) external note {
         require(era <= now, "Vow/wait-not-finished");
         Sin = sub(Sin, sin[era]);
         sin[era] = 0;


### PR DESCRIPTION
`Vow.wait` exists in order to avoid creating unnecessary `flop` auctions immediately after a position has entered liquidation (creating bad debt), but before the `flip` auction has had time to finish and cancel the bad debt. Currently, `Vow.wait` has to be configured to apply to debt generated by all collateral types, meaning that it should be set to the maximum running time of any `flip` auction. This is a limitation, since some future collateral types may wish to allow much longer liquidation auction durations than the existing ones, which would force `wait` to be longer, unnecessarily delaying `flop` auctions for other collateral types.

This PR makes `wait` configurable per `Ilk`, as `Vow.ilks(ilk).wait`.

TODOs:
- adjust tests