### PR TITLE
feat: Add Keeper Liquidation Incentive (SC-6597)

### DIFF
--- a/src/dog.sol
+++ b/src/dog.sol
@@ -109,7 +109,7 @@ contract Dog is LibNote {
         require(y == 0 || (z = x * y) / y == x);
     }
     function wmul(uint x, uint y) internal pure returns (uint z) {
-        z = add(mul(x, y), WAD / 2) / WAD;
+        z = mul(x, y) / WAD;
     }
 
     // --- Administration ---

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -38,6 +38,7 @@ interface VatLike {
         uint256 art   // [wad]
     );
     function grab(bytes32,address,address,address,int256,int256) external;
+    function suck(address,address,uint256) external;
     function hope(address) external;
     function nope(address) external;
 }
@@ -69,6 +70,7 @@ contract Dog is LibNote {
     uint256 public live;  // Active Flag
     VatLike public vat;   // CDP Engine
     VowLike public vow;   // Debt Engine
+    uint256 public tip;   // Keeper liquidation incentive                         [rad]
     uint256 public Hole;  // Max DAI needed to cover debt+fees of active auctions [rad]
     uint256 public Dirt;  // Amt DAI needed to cover debt+fees of active auctions [rad]
 
@@ -113,6 +115,7 @@ contract Dog is LibNote {
     }
     function file(bytes32 what, uint256 data) external note auth {
         if (what == "Hole") Hole = data;
+        else if (what == "tip") tip = data;
         else revert("Dog/file-unrecognized-param");
     }
     function file(bytes32 ilk, bytes32 what, uint256 data) external note auth {
@@ -179,6 +182,8 @@ contract Dog is LibNote {
                 usr: urn
             });
         }
+
+        vat.suck(address(vow), msg.sender, tip);
 
         emit Bark(ilk, urn, dink, dart, due, milk.clip, id);
     }

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -63,8 +63,8 @@ contract Dog is LibNote {
         uint256 chop;  // Liquidation Penalty                                          [wad]
         uint256 hole;  // Max DAI needed to cover debt+fees of active auctions per ilk [rad]
         uint256 dirt;  // Amt DAI needed to cover debt+fees of active auctions per ilk [rad]
-        uint256 chip;  // Percentage of tab to suck from vat to incentivize keepers    [wad]
-        uint256 tip;   // Flat fee to suck from vat to incentivize keepers             [rad]
+        uint256 chip;  // Percentage of tab to suck from vow to incentivize keepers    [wad]
+        uint256 tip;   // Flat fee to suck from vow to incentivize keepers             [rad]
     }
 
     mapping (bytes32 => Ilk) public ilks;

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -45,6 +45,10 @@ contract Guy {
             data: data
         });
     }
+
+    function bark(Dog dog, bytes32 ilk, address urn) external {
+        dog.bark(ilk, urn);
+    }
 }
 
 contract ClipperTest is DSTest {
@@ -392,12 +396,12 @@ contract ClipperTest is DSTest {
         assertEq(uint256(tic), 0);
         assertEq(top, 0);
         assertEq(vat.gem(ilk, me), 960 ether);
-        assertEq(vat.dai(me), rad(100 ether)); 
+        assertEq(vat.dai(ali), rad(1000 ether));
         (ink, art) = vat.urns(ilk, me);
         assertEq(ink, 40 ether);
         assertEq(art, 100 ether);
 
-        dog.bark(ilk, me);
+        Guy(ali).bark(dog, ilk, me);
 
         assertEq(clip.kicks(), 1);
         (pos, tab, lot, usr, tic, top) = clip.sales(1);
@@ -408,7 +412,7 @@ contract ClipperTest is DSTest {
         assertEq(uint256(tic), now);
         assertEq(top, ray(4 ether));
         assertEq(vat.gem(ilk, me), 960 ether);
-        assertEq(vat.dai(me), rad(200 ether)); // Paid "tip" amount of DAI for calling bark()
+        assertEq(vat.dai(ali), rad(1100 ether)); // Paid "tip" amount of DAI for calling bark()
         (ink, art) = vat.urns(ilk, me);
         assertEq(ink, 0 ether);
         assertEq(art, 0 ether);
@@ -433,7 +437,7 @@ contract ClipperTest is DSTest {
 
         clip.file(bytes32("buf"),  ray(1.25 ether)); // 25% Initial price buffer
 
-        dog.bark(ilk, me);
+        Guy(ali).bark(dog, ilk, me);
 
         assertEq(clip.kicks(), 2);
         (pos, tab, lot, usr, tic, top) = clip.sales(2);
@@ -444,7 +448,7 @@ contract ClipperTest is DSTest {
         assertEq(uint256(tic), now);
         assertEq(top, ray(5 ether));
         assertEq(vat.gem(ilk, me), 920 ether);
-        assertEq(vat.dai(me), rad(400 ether)); // Paid "tip" amount of DAI for calling bark() (balance was 300 before bark)
+        assertEq(vat.dai(ali), rad(1200 ether)); // Paid "tip" amount of DAI for calling bark()
         (ink, art) = vat.urns(ilk, me);
         assertEq(ink, 0 ether);
         assertEq(art, 0 ether);

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -181,6 +181,7 @@ contract ClipperTest is DSTest {
         dog.file(ilk, "chop", 1.1 ether); // 10% chop
         dog.file(ilk, "hole", rad(1000 ether));
         dog.file("Hole", rad(1000 ether));
+        dog.file("tip",  rad(100 ether));
         dog.rely(address(clip));
 
         vat.rely(address(clip));
@@ -391,6 +392,7 @@ contract ClipperTest is DSTest {
         assertEq(uint256(tic), 0);
         assertEq(top, 0);
         assertEq(vat.gem(ilk, me), 960 ether);
+        assertEq(vat.dai(me), rad(100 ether)); 
         (ink, art) = vat.urns(ilk, me);
         assertEq(ink, 40 ether);
         assertEq(art, 100 ether);
@@ -406,6 +408,7 @@ contract ClipperTest is DSTest {
         assertEq(uint256(tic), now);
         assertEq(top, ray(4 ether));
         assertEq(vat.gem(ilk, me), 960 ether);
+        assertEq(vat.dai(me), rad(200 ether)); // Paid "tip" amount of DAI for calling bark()
         (ink, art) = vat.urns(ilk, me);
         assertEq(ink, 0 ether);
         assertEq(art, 0 ether);
@@ -441,6 +444,7 @@ contract ClipperTest is DSTest {
         assertEq(uint256(tic), now);
         assertEq(top, ray(5 ether));
         assertEq(vat.gem(ilk, me), 920 ether);
+        assertEq(vat.dai(me), rad(400 ether)); // Paid "tip" amount of DAI for calling bark() (balance was 300 before bark)
         (ink, art) = vat.urns(ilk, me);
         assertEq(ink, 0 ether);
         assertEq(art, 0 ether);

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -185,7 +185,6 @@ contract ClipperTest is DSTest {
         dog.file(ilk, "chop", 1.1 ether); // 10% chop
         dog.file(ilk, "hole", rad(1000 ether));
         dog.file("Hole", rad(1000 ether));
-        dog.file("tip",  rad(100 ether));
         dog.rely(address(clip));
 
         vat.rely(address(clip));
@@ -387,6 +386,9 @@ contract ClipperTest is DSTest {
         uint256 ink;
         uint256 art;
 
+        dog.file(ilk, "tip",  rad(100 ether)); // Flat fee of 100 DAI
+        dog.file(ilk, "chip", 0);              // No linear increase
+
         assertEq(clip.kicks(), 0);
         (pos, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
@@ -437,7 +439,10 @@ contract ClipperTest is DSTest {
 
         clip.file(bytes32("buf"),  ray(1.25 ether)); // 25% Initial price buffer
 
-        Guy(ali).bark(dog, ilk, me);
+        dog.file(ilk, "tip",  rad(100 ether)); // Flat fee of 100 DAI
+        dog.file(ilk, "chip", 0.02 ether);     // Linear increase of 2% of tab
+
+        Guy(bob).bark(dog, ilk, me);
 
         assertEq(clip.kicks(), 2);
         (pos, tab, lot, usr, tic, top) = clip.sales(2);
@@ -448,7 +453,7 @@ contract ClipperTest is DSTest {
         assertEq(uint256(tic), now);
         assertEq(top, ray(5 ether));
         assertEq(vat.gem(ilk, me), 920 ether);
-        assertEq(vat.dai(ali), rad(1200 ether)); // Paid "tip" amount of DAI for calling bark()
+        assertEq(vat.dai(bob), rad(1000 ether) + rad(100 ether) + tab * 0.02 ether / WAD); // Paid (tip + tab * chip) amount of DAI for calling bark()
         (ink, art) = vat.urns(ilk, me);
         assertEq(ink, 0 ether);
         assertEq(art, 0 ether);
@@ -558,7 +563,7 @@ contract ClipperTest is DSTest {
 
     function test_Hole_hole() public {
         assertEq(dog.Dirt(), 0);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me);
@@ -566,7 +571,7 @@ contract ClipperTest is DSTest {
         (, uint256 tab,,,,) = clip.sales(1);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt) = dog.ilks(ilk);
+        (,,, dirt,,) = dog.ilks(ilk);
         assertEq(dirt, tab);
 
         bytes32 ilk2 = "silver";
@@ -599,8 +604,8 @@ contract ClipperTest is DSTest {
         (, uint256 tab2,,,,) = clip2.sales(1);
 
         assertEq(dog.Dirt(), tab + tab2);
-        (,,, dirt) = dog.ilks(ilk);
-        (,,, uint256 dirt2) = dog.ilks(ilk2);
+        (,,, dirt,,) = dog.ilks(ilk);
+        (,,, uint256 dirt2,,) = dog.ilks(ilk2);
         assertEq(dirt, tab);
         assertEq(dirt2, tab2);
     }
@@ -612,7 +617,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether);
 
         assertEq(dog.Dirt(), 0);
-        (,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
+        (,uint256 chop,, uint256 dirt,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me);
@@ -628,7 +633,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether - tab * WAD / rate / chop);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt) = dog.ilks(ilk);
+        (,,, dirt,,) = dog.ilks(ilk);
         assertEq(dirt, tab);
     }
 
@@ -639,7 +644,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether);
 
         assertEq(dog.Dirt(), 0);
-        (,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
+        (,uint256 chop,, uint256 dirt,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me);
@@ -655,7 +660,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether - tab * WAD / rate / chop);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt) = dog.ilks(ilk);
+        (,,, dirt,,) = dog.ilks(ilk);
         assertEq(dirt, tab);
     }
 

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -442,6 +442,8 @@ contract ClipperTest is DSTest {
         dog.file(ilk, "tip",  rad(100 ether)); // Flat fee of 100 DAI
         dog.file(ilk, "chip", 0.02 ether);     // Linear increase of 2% of tab
 
+        assertEq(vat.dai(bob), rad(1000 ether));
+
         Guy(bob).bark(dog, ilk, me);
 
         assertEq(clip.kicks(), 2);

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -372,7 +372,7 @@ contract ClipperTest is DSTest {
 
     function test_get_chop() public {
         uint256 chop = dog.chop(ilk);
-        (, uint256 chop2,,) = dog.ilks(ilk);
+        (, uint256 chop2,,,,) = dog.ilks(ilk);
         assertEq(chop, chop2);
     }
     


### PR DESCRIPTION
Making this PR to start discussing how to incentivize keepers to liquidate vaults in LIQ-2.0.

I have considered the following approaches:

1. Use `vat.suck()` in `dog.bark()` with a governance parameter `tip` set as a constant value of `dai` used for all ilks.
2. Use `vat.suck()` in `dog.bark()` with a governance parameter `tip` set as a constant value of `dai` used per ilk.
3. Use `vat.suck()` in `dog.bark()` with a governance parameter `tip` set as a percentage of `due` for a `barked` vault used for all ilks.
4. Use `vat.suck()` in `dog.bark()` with a governance parameter `tip` set as a percentage value of `due` for a `barked` vault used per ilk.
5. Dedicate a portion of `chop` for liquidators to claim on successful liquidation.
6. Flux a portion of collateral to liquidator on `dog.bark()`.
7. Gas refund token functionality.

I have implemented option 1 in this PR as I believe it is the simplest solution and incentivizes keepers in a fair manner, but I am very open to other suggestions and general discussion about the optimal solution.
