### PR TITLE
feat: Add Dusty `bite` Check (SC-6351)

### DIFF
--- a/src/dog.sol
+++ b/src/dog.sol
@@ -92,6 +92,7 @@ contract Dog /* is LibNote */ {
 
     // --- Math ---
     uint256 constant WAD = 10 ** 18;
+    uint256 constant RAY = 10 ** 27;
 
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         if (x > y) { z = y; } else { z = x; }
@@ -148,6 +149,9 @@ contract Dog /* is LibNote */ {
             require(room > 0 && room >= dust, "Dog/liquidation-limit-hit");
 
             dart = min(art, mul(room, WAD) / rate / milk.chop);
+
+            // Verify that CDP is not left in a dusty state
+            require(dart == art || mul(art - dart, RAY) >= dust, "Dog/leaves-dust");
         }
 
         uint256 dink = min(ink, mul(ink, dart) / art);
@@ -155,7 +159,6 @@ contract Dog /* is LibNote */ {
         require(dink > 0, "Dog/null-auction");
         require(dart <= 2**255 && dink <= 2**255, "Dog/overflow");
 
-        // This may leave the CDP in a dusty state
         vat.grab(
             ilk, urn, milk.clip, address(vow), -int256(dink), -int256(dart)
         );

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -92,7 +92,6 @@ contract Dog /* is LibNote */ {
 
     // --- Math ---
     uint256 constant WAD = 10 ** 18;
-    uint256 constant RAY = 10 ** 27;
 
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         if (x > y) { z = y; } else { z = x; }

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -151,7 +151,7 @@ contract Dog /* is LibNote */ {
             dart = min(art, mul(room, WAD) / rate / milk.chop);
 
             // Verify that CDP is not left in a dusty state
-            require(dart == art || mul(art - dart, RAY) >= dust, "Dog/leaves-dust");
+            require(dart == art || mul(art - dart, rate) >= dust, "Dog/leaves-dust");
         }
 
         uint256 dink = min(ink, mul(ink, dart) / art);

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -529,11 +529,11 @@ contract ClipperTest is DSTest {
         assertEq(ink, 40 ether);
         assertEq(art, 100 ether);
 
-        assertTrue(!try_bark(ilk, me)); // (art - dart) * rate = (100 - 80) * rate < dust (= 20 * rate)
+        assertTrue(!try_bark(ilk, me)); // (art - dart) * rate = (100 - (80 + 1 wei)) * rate < dust (= 20 * rate)
 
         dog.file(ilk, "hole", mul(80 ether, rate)); // Makes room = 80 WAD + 1 wei in normalized debt
 
-        assertTrue( try_bark(ilk, me)); // art - dart = 100 - 80 == dust (= 20 * rate)
+        assertTrue( try_bark(ilk, me)); // (art - dart) * rate = (100 - 80) == dust (= 20 * rate)
 
         assertEq(clip.kicks(), 1);
         (pos, tab, lot, usr, tic, top) = clip.sales(1);

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.5.12;
 import "ds-test/test.sol";
 import "ds-token/token.sol";
 import "ds-value/value.sol";
-import "ds-math/math.sol";
 
 import {Vat}     from "../vat.sol";
 import {Spotter} from "../spot.sol";

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -7,7 +7,6 @@ import "ds-value/value.sol";
 import {Vat}     from "../vat.sol";
 import {Spotter} from "../spot.sol";
 import {Vow}     from "../vow.sol";
-import {Jug}     from "../jug.sol";
 
 import {Clipper} from "../clip.sol";
 import "../abaci.sol";
@@ -56,7 +55,6 @@ contract ClipperTest is DSTest {
     Spotter spot;
     Vow     vow;
     DSValue pip;
-    Jug     jug;
 
     Clipper clip;
 
@@ -161,11 +159,7 @@ contract ClipperTest is DSTest {
         vat.rely(address(dog));
         vow.rely(address(dog));
 
-        jug = new Jug(address(vat));
-        vat.rely(address(jug));
-
         vat.init(ilk);
-        jug.init(ilk);
 
         vat.slip(ilk, me, 1000 ether);
 
@@ -507,10 +501,9 @@ contract ClipperTest is DSTest {
         uint256 ink;
         uint256 art;
 
-        jug.file(ilk, "duty", 1000000001243680656318820312);
-        hevm.warp(now + 1 days);
-        jug.drip(ilk);
+        vat.fold(ilk, address(vow), int256(ray(0.02 ether)));
         (, uint256 rate,,,) = vat.ilks(ilk);
+        assertEq(rate, ray(1.02 ether));
 
         dog.file(ilk, "hole", mul(80 ether + 1, rate)); // Makes room = 80 WAD + 1 wei in normalized debt
         dog.file(ilk, "chop", 1 ether);                 // 0% chop (for precise calculations)


### PR DESCRIPTION
Adds a check to ensure that when `dog.bark()` is called,  the liquidated CDP is not left in a dusty state.