### PR TITLE
feat: Add Liquidation Price into `top` Calculation (SC-6715)

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -117,8 +117,6 @@ contract Clipper is LibNote {
         address indexed usr
     );
 
-    event Debug(uint i, uint val);
-
     // --- Init ---
     constructor(address vat_, address spot_, address dog_, bytes32 ilk_) public {
         vat  = VatLike(vat_);
@@ -205,11 +203,6 @@ contract Clipper is LibNote {
         (PipLike pip, uint256 mat) = spot.ilks(ilk);
         (bytes32 val, bool has) = pip.peek();
         require(has, "Clipper/invalid-price");
-
-        emit Debug(1, lip);
-        emit Debug(2, rmul(lip, mat));
-        emit Debug(3, rdiv(mul(uint256(val), BLN), spot.par()));
-
         sales[id].top = rmul(max(rmul(lip, mat), rdiv(mul(uint256(val), BLN), spot.par())), buf);
 
         emit Kick(id, sales[id].top, tab, lot, usr);

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -101,7 +101,7 @@ contract Clipper is LibNote {
 
     event Take(
         uint256 indexed id, 
-        uint256 max,
+        uint256 cap,
         uint256 price,
         uint256 owe,
         uint256 tab,
@@ -235,7 +235,7 @@ contract Clipper is LibNote {
     // Buy amt of collateral from auction indexed by id
     function take(uint256 id,           // Auction id
                   uint256 amt,          // Upper limit on amount of collateral to buy  [wad]
-                  uint256 max,          // Maximum acceptable price (DAI / collateral) [ray]
+                  uint256 cap,          // Maximum acceptable price (DAI / collateral) [ray]
                   address who,          // Receiver of collateral, payer of DAI, and external call address
                   bytes calldata data   // Data to pass in external call; if length 0, no call is done
     ) external lock isStopped(2) {
@@ -250,7 +250,7 @@ contract Clipper is LibNote {
         require(sub(now, sale.tic) <= tail && rdiv(price, sale.top) >= cusp, "Clipper/needs-reset");
 
         // Ensure price is acceptable to buyer
-        require(max >= price, "Clipper/too-expensive");
+        require(cap >= price, "Clipper/too-expensive");
 
         // Purchase as much as possible, up to amt
         uint256 slice = min(sale.lot, amt);  // slice <= lot
@@ -297,7 +297,7 @@ contract Clipper is LibNote {
             sales[id].lot = sale.lot;
         }
 
-        emit Take(id, max, price, owe, sale.tab, sale.lot, sale.usr);
+        emit Take(id, cap, price, owe, sale.tab, sale.lot, sale.usr);
     }
 
     function _remove(uint256 id) internal {

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -117,6 +117,8 @@ contract Clipper is LibNote {
         address indexed usr
     );
 
+    event Debug(uint i, uint val);
+
     // --- Init ---
     constructor(address vat_, address spot_, address dog_, bytes32 ilk_) public {
         vat  = VatLike(vat_);
@@ -203,6 +205,11 @@ contract Clipper is LibNote {
         (PipLike pip, uint256 mat) = spot.ilks(ilk);
         (bytes32 val, bool has) = pip.peek();
         require(has, "Clipper/invalid-price");
+
+        emit Debug(1, lip);
+        emit Debug(2, rmul(lip, mat));
+        emit Debug(3, rdiv(mul(uint256(val), BLN), spot.par()));
+
         sales[id].top = rmul(max(rmul(lip, mat), rdiv(mul(uint256(val), BLN), spot.par())), buf);
 
         emit Kick(id, sales[id].top, tab, lot, usr);

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -203,7 +203,7 @@ contract Clipper is LibNote {
         (PipLike pip, uint256 mat) = spot.ilks(ilk);
         (bytes32 val, bool has) = pip.peek();
         require(has, "Clipper/invalid-price");
-        sales[id].top = rmul(rdiv(max(rmul(lip, mat), mul(uint256(val), BLN)), spot.par()), buf);
+        sales[id].top = rmul(max(rmul(lip, mat), rdiv(mul(uint256(val), BLN), spot.par())), buf);
 
         emit Kick(id, sales[id].top, tab, lot, usr);
     }

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -105,10 +105,6 @@ contract Dog is LibNote {
     function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require(y == 0 || (z = x * y) / y == x);
     }
-    function div(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require(y > 0);
-        z = x / y;
-    }
 
     // --- Administration ---
     function file(bytes32 what, address data) external note auth {

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -180,7 +180,7 @@ contract Dog is LibNote {
             id = ClipperLike(milk.clip).kick({
                 tab: tab,
                 lot: dink,
-                lip: div(mul(art, rate), ink),
+                lip: due / dink,
                 usr: urn
             });
         }

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -22,7 +22,7 @@ pragma solidity >=0.5.12;
 import "./lib.sol";
 
 interface ClipperLike {
-    function kick(uint256 tab, uint256 lot, address usr) external returns (uint256);
+    function kick(uint256 tab, uint256 lot, uint256 lip, address usr) external returns (uint256);
 }
 
 interface VatLike {
@@ -105,6 +105,10 @@ contract Dog is LibNote {
     function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require(y == 0 || (z = x * y) / y == x);
     }
+    function div(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require(y > 0);
+        z = x / y;
+    }
 
     // --- Administration ---
     function file(bytes32 what, address data) external note auth {
@@ -176,6 +180,7 @@ contract Dog is LibNote {
             id = ClipperLike(milk.clip).kick({
                 tab: tab,
                 lot: dink,
+                lip: div(mul(art, rate), ink),
                 usr: urn
             });
         }

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -31,7 +31,7 @@ contract Guy {
     function take(
         uint256 id,           
         uint256 amt,          
-        uint256 max,         
+        uint256 cap,         
         address who,   
         bytes calldata data
     ) 
@@ -40,7 +40,7 @@ contract Guy {
         clip.take({
             id: id,
             amt: amt,
-            max: max,
+            cap: cap,
             who: who,
             data: data
         });
@@ -700,7 +700,7 @@ contract ClipperTest is DSTest {
         Guy(ali).take({
             id:  1,
             amt: 20 ether,
-            max: ray(6.25 ether),
+            cap: ray(6.25 ether),
             who: address(ali),
             data: ""
         });
@@ -724,7 +724,7 @@ contract ClipperTest is DSTest {
         Guy(ali).take({
             id:  1,
             amt: 17.6 ether,
-            max: ray(6.25 ether),
+            cap: ray(6.25 ether),
             who: address(ali),
             data: ""
         });
@@ -748,7 +748,7 @@ contract ClipperTest is DSTest {
         Guy(ali).take({
             id:  1,
             amt: 10 ether,     
-            max: ray(6.25 ether),
+            cap: ray(6.25 ether),
             who: address(ali),
             data: ""
         });
@@ -768,11 +768,11 @@ contract ClipperTest is DSTest {
     }   
 
     function testFail_take_bid_too_low() public takeSetup {
-        // Bid so max (= 6.25 ray - 1) < price (= top = 6.25 ray) (fails with "Clipper/too-expensive")
+        // Bid so cap (= 6.25 ray - 1) < price (= top = 6.25 ray) (fails with "Clipper/too-expensive")
         Guy(ali).take({
             id:  1,
             amt: 22 ether,
-            max: ray(6.25 ether) - 1,
+            cap: ray(6.25 ether) - 1,
             who: address(ali),
             data: ""
         });
@@ -783,7 +783,7 @@ contract ClipperTest is DSTest {
         Guy(ali).take({
             id:  1,
             amt: 17.6 ether - 1,
-            max: ray(5 ether),
+            cap: ray(5 ether),
             who: address(ali),
             data: ""
         });
@@ -801,7 +801,7 @@ contract ClipperTest is DSTest {
         Guy(ali).take({
             id:  1,
             amt: 10 ether,     
-            max: ray(6.25 ether),
+            cap: ray(6.25 ether),
             who: address(ali),
             data: ""
         });
@@ -825,7 +825,7 @@ contract ClipperTest is DSTest {
         Guy(bob).take({
             id:  1,
             amt: 30 ether,     // Buy the rest of the lot 
-            max: ray(5 ether), // 6.25 * 0.99 ** 30 = 4.623127333676751 RAY => max > price
+            cap: ray(5 ether), // 6.25 * 0.99 ** 30 = 4.623127333676751 RAY => cap > price
             who: address(bob),
             data: ""
         });
@@ -965,7 +965,7 @@ contract ClipperTest is DSTest {
         Guy(ali).take({
             id:  1,
             amt: 20 ether,
-            max: ray(6.25 ether),
+            cap: ray(6.25 ether),
             who: address(ali),
             data: ""
         });
@@ -978,7 +978,7 @@ contract ClipperTest is DSTest {
         Guy(ali).take({
             id:  1,
             amt: 20 ether,
-            max: ray(6.25 ether),
+            cap: ray(6.25 ether),
             who: address(ali),
             data: ""
         });


### PR DESCRIPTION
Adding this PR to start a discussion about adding the liquidation price (`(art * rate / ink) * mat`) into the `top` calculation.