### PR TITLE
change price API to accept seconds elapsed since auction start

### DIFF
--- a/src/abaci.sol
+++ b/src/abaci.sol
@@ -15,14 +15,16 @@
 
 pragma solidity >=0.5.12;
 
+/*
 interface Abacus {
     // 1st arg: initial price               [ray]
     // 2nd arg: seconds since auction start [seconds]
     // returns: current auction price       [ray]
     function price(uint256, uint256) external view returns (uint256);
 }
+*/
 
-contract LinearDecrease is Abacus {
+contract LinearDecrease /* is Abacus */ {
 
     // --- Auth ---
     mapping (address => uint256) public wards;
@@ -61,13 +63,13 @@ contract LinearDecrease is Abacus {
         z = z / RAY;
     }
 
-    function price(uint256 top, uint256 dur) override external view returns (uint256) {
+    function price(uint256 top, uint256 dur) /* override */ external view returns (uint256) {
         if (dur >= tau) return 0;
         return rmul(top, mul(tau - dur, RAY) / tau);
     }
 }
 
-contract StairstepExponentialDecrease is Abacus {
+contract StairstepExponentialDecrease /* is Abacus */ {
 
     // --- Auth ---
     mapping (address => uint256) public wards;
@@ -136,7 +138,7 @@ contract StairstepExponentialDecrease is Abacus {
         }
     }
 
-    function price(uint256 top, uint256 dur) override external view returns (uint256) {
+    function price(uint256 top, uint256 dur) /* override */ external view returns (uint256) {
         return rmul(top, rpow(sub(RAY, cut), dur / step, RAY));
     }
 }

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -219,7 +219,7 @@ contract Clipper {
         require(sale.tab > 0, "Clipper/not-running-auction");
 
         // Compute current price [ray]
-        uint256 price = calc.price(sale.top, sale.tic);
+        uint256 price = calc.price(sale.top, sub(now, sale.tic));
 
         // Check that auction needs reset
         require(sub(now, sale.tic) > tail || rdiv(price, sale.top) < cusp, "Clipper/cannot-reset");
@@ -248,7 +248,7 @@ contract Clipper {
         require(sale.tab > 0, "Clipper/not-running-auction");
 
         // Compute current price [ray]
-        uint256 price = calc.price(sale.top, sale.tic);
+        uint256 price = calc.price(sale.top, sub(now, sale.tic));
 
         // Check that auction doesn't need reset
         require(sub(now, sale.tic) <= tail && rdiv(price, sale.top) >= cusp, "Clipper/needs-reset");

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -228,13 +228,13 @@ contract ClipperTest is DSTest {
         hevm.warp(startTime);
         calc.file(bytes32("step"), step);
         calc.file(bytes32("cut"),  cut);
-        price = calc.price(top, tic);
+        price = calc.price(top, now - tic);
         assertEq(price, top);
 
         for(uint256 i = 1; i < testTime; i += 1) {
             hevm.warp(startTime + i);
             lastPrice = price;
-            price = calc.price(top, tic);
+            price = calc.price(top, now - tic);
             // Stairstep calculation
             if (i % step == 0) { testPrice = lastPrice * (RAY - percentDecrease) / RAY; }
             else               { testPrice = lastPrice; }
@@ -326,47 +326,47 @@ contract ClipperTest is DSTest {
 
         uint256 top = 1000 * RAY;
         uint256 tic = now; // Start of auction
-        uint256 price = calc.price(top, tic);
+        uint256 price = calc.price(top, now - tic);
         assertEq(price, top);
 
         hevm.warp(startTime + 360);                // 6min in,   1/10 done
-        price = calc.price(top, tic);
+        price = calc.price(top, now - tic);
         assertEq(price, (1000 - 100) * RAY);
 
         hevm.warp(startTime + 360 * 2);            // 12min in,  2/10 done
-        price = calc.price(top, tic);
+        price = calc.price(top, now - tic);
         assertEq(price, (1000 - 100 * 2) * RAY);
 
         hevm.warp(startTime + 360 * 3);            // 18min in,  3/10 done
-        price = calc.price(top, tic);
+        price = calc.price(top, now - tic);
         assertEq(price, (1000 - 100 * 3) * RAY);
 
         hevm.warp(startTime + 360 * 4);            // 24min in,  4/10 done
-        price = calc.price(top, tic);
+        price = calc.price(top, now - tic);
         assertEq(price, (1000 - 100 * 4) * RAY);
 
         hevm.warp(startTime + 360 * 5);            // 30min in,  5/10 done
-        price = calc.price(top, tic);
+        price = calc.price(top, now - tic);
         assertEq(price, (1000 - 100 * 5) * RAY);
 
         hevm.warp(startTime + 360 * 6);            // 36min in,  6/10 done
-        price = calc.price(top, tic);
+        price = calc.price(top, now - tic);
         assertEq(price, (1000 - 100 * 6) * RAY);
 
         hevm.warp(startTime + 360 * 7);            // 42min in,  7/10 done
-        price = calc.price(top, tic);
+        price = calc.price(top, now - tic);
         assertEq(price, (1000 - 100 * 7) * RAY);
 
         hevm.warp(startTime + 360 * 8);            // 48min in,  8/10 done
-        price = calc.price(top, tic);
+        price = calc.price(top, now - tic);
         assertEq(price, (1000 - 100 * 8) * RAY);
 
         hevm.warp(startTime + 360 * 9);            // 54min in,  9/10 done
-        price = calc.price(top, tic);
+        price = calc.price(top, now - tic);
         assertEq(price, (1000 - 100 * 9) * RAY);
 
         hevm.warp(startTime + 360 * 10);           // 60min in, 10/10 done
-        price = calc.price(top, tic);
+        price = calc.price(top, now - tic);
         assertEq(price, 0);
     }
 
@@ -793,7 +793,7 @@ contract ClipperTest is DSTest {
 
         hevm.warp(now + 30); 
 
-        uint256 price = clip.calc().price(top, tic);
+        uint256 price = clip.calc().price(top, now - tic);
         Guy(bob).take({
             id:  1,
             amt: 30 ether,     // Buy the rest of the lot 


### PR DESCRIPTION
This should be a bit friendlier to integrators wanting to check what the price will be at some time in the future. It also makes more logical sense--the time elapsed since the start of the auction is all that matters, not the exact start time, so this is more explicit and thus clearer to readers of the code.