### PR TITLE
refactor: Minor `dink` Gas Optimization

### DIFF
--- a/src/dog.sol
+++ b/src/dog.sol
@@ -177,7 +177,7 @@ contract Dog {
             require(dart == art || mul(art - dart, rate) >= dust, "Dog/leaves-dust");
         }
 
-        uint256 dink = min(ink, mul(ink, dart) / art);
+        uint256 dink = mul(ink, dart) / art;
 
         require(dink > 0, "Dog/null-auction");
         require(dart <= 2**255 && dink <= 2**255, "Dog/overflow");


### PR DESCRIPTION
Since `dart <= art`, we don't need to check `min` since `dink = ink` when `dart = art`.

Gas calculations:

```
360644 - full hole, old
360569 - full hole, new
    75 - gas savings
358067 - partial hole, old
357982 - partial hole, new
    85 - gas savings
```