### PR TITLE
fix: Input and state validation

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -222,7 +222,7 @@ contract Clipper {
     function redo(uint256 id) external isStopped(2) {
         // Read auction data
         Sale memory sale = sales[id];
-        require(sale.tab > 0, "Clipper/not-running-auction");
+        require(sale.usr != address(0), "Clipper/not-running-auction");
 
         // Compute current price [ray]
         uint256 price = calc.price(sale.top, sub(now, sale.tic));
@@ -251,7 +251,7 @@ contract Clipper {
     ) external lock isStopped(2) {
         // Read auction data
         Sale memory sale = sales[id];
-        require(sale.tab > 0, "Clipper/not-running-auction");
+        require(sale.usr != address(0), "Clipper/not-running-auction");
 
         // Compute current price [ray]
         uint256 price = calc.price(sale.top, sub(now, sale.tic));
@@ -342,7 +342,7 @@ contract Clipper {
         // Compute current price [ray]
         uint256 price = calc.price(sale.top, sub(now, sale.tic));
 
-        return sale.tab > 0 && done(sale, price);
+        return sale.usr != address(0) && done(sale, price);
     }
 
     // Internally returns boolean for if an auction needs a redo
@@ -358,9 +358,10 @@ contract Clipper {
 
     // Cancel an auction during ES
     function yank(uint id) external auth {
-        require(sales[id].usr != address(0), "Clipper/usr-not-set");
-        dog.digs(ilk, sales[id].tab);
-        vat.flux(ilk, address(this), msg.sender, sales[id].lot);
+        Sale memory sale = sales[id];
+        require(sale.usr != address(0), "Clipper/not-running-auction");
+        dog.digs(ilk, sale.tab);
+        vat.flux(ilk, address(this), msg.sender, sale.lot);
         _remove(id);
         emit Yank();
     }

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -186,10 +186,16 @@ contract Clipper {
     // --- Auction ---
 
     // start an auction
+    // note: trusts the caller to transfer collateral to the contract
     function kick(uint256 tab,  // Debt             [rad]
                   uint256 lot,  // Collateral       [wad]
                   address usr   // Liquidated CDP
     ) external auth isStopped(1) returns (uint256 id) {
+        // Input validation
+        require(tab  >          0, "Clipper/zero-tab");
+        require(lot  >          0, "Clipper/zero-lot");
+        require(usr != address(0), "Clipper/zero-usr");
+
         require(kicks < uint256(-1), "Clipper/overflow");
         id = ++kicks;
         active.push(id);

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -302,6 +302,27 @@ contract ClipperTest is DSTest {
         assertEq(vat.dai(bob), rad(1000 ether) + rad(100 ether) + due * 0.02 ether / WAD); // Paid (tip + due * chip) amount of DAI for calling bark()
     }
 
+    function try_kick(uint256 tab, uint256 lot, address usr) internal returns (bool ok) {
+        string memory sig = "kick(uint256,uint256,address)";
+        (ok,) = address(clip).call(abi.encodeWithSignature(sig, tab, lot, usr));
+    }
+
+    function test_kick_basic() public {
+        assertTrue(try_kick(1 ether, 2 ether, address(1)));
+    }
+
+    function test_kick_zero_tab() public {
+        assertTrue(!try_kick(0, 2 ether, address(1)));
+    }
+
+    function test_kick_zero_lot() public {
+        assertTrue(!try_kick(1 ether, 0, address(1)));
+    }
+
+    function test_kick_zero_usr() public {
+        assertTrue(!try_kick(1 ether, 2 ether, address(0)));
+    }
+
     function try_bark(bytes32 ilk, address urn) internal returns (bool ok) {
         string memory sig = "bark(bytes32,address)";
         (ok,) = address(dog).call(abi.encodeWithSignature(sig, ilk, urn));


### PR DESCRIPTION
Added input validation to `kick`; this is not strictly necessary, since the caller must be authorized, but is prudent for "future proofing" IMO and allows correctness of other logic in the contract to be guaranteed without depending on callers to be well-behaved.

I also regularized the check for whether or not an auction is running (`yank` was doing it differently and using a different mechanism)--I chose checking `sales[id].usr` to standardize on, but I could be talked into any equivalently good way of doing it.