### PR TITLE
Liq-2.0: remove some whitespace and change to BIL

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -103,7 +103,7 @@ contract Clipper {
         address indexed usr
     );
     event Take(
-        uint256 indexed id, 
+        uint256 indexed id,
         uint256 max,
         uint256 price,
         uint256 owe,
@@ -229,7 +229,7 @@ contract Clipper {
 
         // Check that auction needs reset
         require(done(sale, price), "Clipper/cannot-reset");
-        
+
         sales[id].tic = uint96(now);
 
         // Could get this from rmul(Vat.ilks(ilk).spot, Spotter.mat()) instead, but if mat has changed since the
@@ -237,7 +237,7 @@ contract Clipper {
         (PipLike pip, ) = spot.ilks(ilk);
         (bytes32 val, bool has) = pip.peek();
         require(has, "Clipper/invalid-price");
-        sales[id].top = rmul(rdiv(mul(uint256(val), 10 ** 9), spot.par()), buf);
+        sales[id].top = rmul(rdiv(mul(uint256(val), BLN), spot.par()), buf);
 
         emit Redo(id, sales[id].top, sales[id].tab, sales[id].lot, sales[id].usr);
     }

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -82,7 +82,7 @@ contract Dog {
     event FileAddress(bytes32 indexed what, address data);
     event FileIlkUint256(bytes32 indexed ilk, bytes32 indexed what, uint256 data);
     event FileIlkClip(bytes32 indexed ilk, bytes32 indexed what, address clip);
-    
+
     event Bark(
       bytes32 indexed ilk,
       address indexed urn,
@@ -163,8 +163,8 @@ contract Dog {
             (,rate, spot,, dust) = vat.ilks(ilk);
             require(spot > 0 && mul(ink, spot) < mul(art, rate), "Dog/not-unsafe");
 
-            // Get the minimum value between: 
-            // 1) Remaining space in the general Hole 
+            // Get the minimum value between:
+            // 1) Remaining space in the general Hole
             // 2) Remaining space in the collateral hole
             uint256 room = min(sub(Hole, Dirt), sub(milk.hole, milk.dirt));
 
@@ -185,7 +185,7 @@ contract Dog {
         vat.grab(
             ilk, urn, milk.clip, address(vow), -int256(dink), -int256(dart)
         );
-        
+
         uint256 due = mul(dart, rate);
         vow.fess(due);
 

--- a/src/end.sol
+++ b/src/end.sol
@@ -319,7 +319,7 @@ contract End is LibNote {
         ClipLike clip = ClipLike(_clip);
         (, uint rate,,,) = vat.ilks(ilk);
         (, uint256 tab, uint256 lot, address usr,,) = clip.sales(id);
-        
+
         vat.suck(address(vow), address(vow),  tab);
         clip.yank(id);
 


### PR DESCRIPTION
- Changes `10 ** 9` to `BIL`
- Remove whitespace