### PR TITLE
Add remaining art to dart to prevent unliquidatable vaults

### DIFF
--- a/src/dog.sol
+++ b/src/dog.sol
@@ -173,15 +173,10 @@ contract Dog {
 
             dart = min(art, mul(room, WAD) / rate / milk.chop);
 
-            uint256 mart = mul(art - dart, rate);
-
-            if (mart < dust) {
+            if (mul(art - dart, rate) < dust) {
                 // avoid leaving a dusty vault to prevent unliquidatable vaults
-                dart = add(dart, mart);
+                dart = art;
             }
-
-            // Verify that CDP is not left in a dusty state
-            require(dart == art || mart >= dust, "Dog/leaves-dust");
         }
 
         uint256 dink = mul(ink, dart) / art;

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -181,7 +181,7 @@ contract Dog {
             }
 
             // Verify that CDP is not left in a dusty state
-            require(dart == art || mul(art - dart, rate) >= dust, "Dog/leaves-dust");
+            require(dart == art || mart >= dust, "Dog/leaves-dust");
         }
 
         uint256 dink = mul(ink, dart) / art;

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -179,7 +179,6 @@ contract Dog {
                 // avoid leaving a dusty vault to prevent unliquidatable vaults
                 dart = add(dart, mart);
             }
-            require(dart == art || mart >= dust, "Dog/leaves-dust");
 
             // Verify that CDP is not left in a dusty state
             require(dart == art || mul(art - dart, rate) >= dust, "Dog/leaves-dust");

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -173,6 +173,14 @@ contract Dog {
 
             dart = min(art, mul(room, WAD) / rate / milk.chop);
 
+            uint256 mart = mul(art - dart, rate);
+
+            if (mart < dust) {
+                // avoid leaving a dusty vault to prevent unliquidatable vaults
+                dart = add(dart, mart);
+            }
+            require(dart == art || mart >= dust, "Dog/leaves-dust");
+
             // Verify that CDP is not left in a dusty state
             require(dart == art || mul(art - dart, rate) >= dust, "Dog/leaves-dust");
         }

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -459,7 +459,7 @@ contract ClipperTest is DSTest {
         assertEq(art, 20 ether);
     }
 
-    function test_bark_not_leaving_dust_over_hole_rate() public {
+    function test_bark_only_leaving_dust_over_hole_rate() public {
         uint256 pos;
         uint256 tab;
         uint256 lot;

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -459,6 +459,7 @@ contract ClipperTest is DSTest {
         assertEq(art, 20 ether);
     }
 
+    // TODO: Check ticket SC-8392
     function test_bark_only_leaving_dust_over_hole_rate() public {
         uint256 pos;
         uint256 tab;


### PR DESCRIPTION
Current situation allows for a large vault to become unliquidatable if it leaves a small dusty amount. 

This adds the dusty amount to the dart to liquidate the entire amount.

This comes at the cost of exceeding the hole, but it prevents leaving a dusty amount and prevents locking the collateral.