### PR TITLE
Add extra function to pay rewards to external address

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -290,7 +290,6 @@ contract Clipper {
         vat.flux(ilk, address(this), who, slice);
 
         // Do external call (if defined)
-        // TODO: do we want to circuit break flash loans?
         if (data.length > 0) {
             ClipperCallee(who).clipperCall(owe, slice, data);
         }

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -150,7 +150,7 @@ contract Dog {
     function chop(bytes32 ilk) external view returns (uint256) { return ilks[ilk].chop; }
 
     // --- CDP Liquidation: all bark and no bite ---
-    function bark(bytes32 ilk, address urn, address guy) public returns (uint256 id) {
+    function bark(bytes32 ilk, address urn, address guy) external returns (uint256 id) {
         require(live == 1, "Dog/not-live");
 
         (uint256 ink, uint256 art) = vat.urns(ilk, urn);
@@ -205,10 +205,6 @@ contract Dog {
         vat.suck(address(vow), guy, add(milk.tip, wmul(due, milk.chip)));
 
         emit Bark(ilk, urn, dink, dart, due, milk.clip, id);
-    }
-
-    function bark(bytes32 ilk, address urn) external returns (uint256 id) {
-        return bark(ilk, urn, msg.sender);
     }
 
     function digs(bytes32 ilk, uint256 rad) external auth {

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -150,7 +150,7 @@ contract Dog {
     function chop(bytes32 ilk) external view returns (uint256) { return ilks[ilk].chop; }
 
     // --- CDP Liquidation: all bark and no bite ---
-    function bark(bytes32 ilk, address urn, address guy) external returns (uint256 id) {
+    function bark(bytes32 ilk, address urn, address usr) external returns (uint256 id) {
         require(live == 1, "Dog/not-live");
 
         (uint256 ink, uint256 art) = vat.urns(ilk, urn);
@@ -202,7 +202,7 @@ contract Dog {
             });
         }
 
-        vat.suck(address(vow), guy, add(milk.tip, wmul(due, milk.chip)));
+        vat.suck(address(vow), usr, add(milk.tip, wmul(due, milk.chip)));
 
         emit Bark(ilk, urn, dink, dart, due, milk.clip, id);
     }

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -150,7 +150,7 @@ contract Dog {
     function chop(bytes32 ilk) external view returns (uint256) { return ilks[ilk].chop; }
 
     // --- CDP Liquidation: all bark and no bite ---
-    function bark(bytes32 ilk, address urn) external returns (uint256 id) {
+    function bark(bytes32 ilk, address urn, address guy) public returns (uint256 id) {
         require(live == 1, "Dog/not-live");
 
         (uint256 ink, uint256 art) = vat.urns(ilk, urn);
@@ -202,9 +202,13 @@ contract Dog {
             });
         }
 
-        vat.suck(address(vow), msg.sender, add(milk.tip, wmul(due, milk.chip)));
+        vat.suck(address(vow), guy, add(milk.tip, wmul(due, milk.chip)));
 
         emit Bark(ilk, urn, dink, dart, due, milk.clip, id);
+    }
+
+    function bark(bytes32 ilk, address urn) external returns (uint256 id) {
+        return bark(ilk, urn, msg.sender);
     }
 
     function digs(bytes32 ilk, uint256 rad) external auth {

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -29,13 +29,13 @@ contract Guy {
     }
 
     function take(
-        uint256 id,           
-        uint256 amt,          
-        uint256 max,         
-        address who,   
+        uint256 id,
+        uint256 amt,
+        uint256 max,
+        address who,
         bytes calldata data
-    ) 
-        external 
+    )
+        external
     {
         clip.take({
             id: id,
@@ -46,8 +46,8 @@ contract Guy {
         });
     }
 
-    function bark(Dog dog, bytes32 ilk, address urn) external {
-        dog.bark(ilk, urn);
+    function bark(Dog dog, bytes32 ilk, address urn, address guy) external {
+        dog.bark(ilk, urn, guy);
     }
 }
 
@@ -112,7 +112,7 @@ contract ClipperTest is DSTest {
         assertEq(art, 100 ether);
 
         assertEq(clip.kicks(), 0);
-        dog.bark(ilk, me);
+        dog.bark(ilk, me, address(this));
         assertEq(clip.kicks(), 1);
 
         (ink, art) = vat.urns(ilk, me);
@@ -130,7 +130,7 @@ contract ClipperTest is DSTest {
         assertEq(vat.gem(ilk, ali), 0);
         assertEq(vat.dai(ali), rad(1000 ether));
         assertEq(vat.gem(ilk, bob), 0);
-        assertEq(vat.dai(bob), rad(1000 ether)); 
+        assertEq(vat.dai(bob), rad(1000 ether));
 
         _;
     }
@@ -190,10 +190,10 @@ contract ClipperTest is DSTest {
         vat.rely(address(clip));
 
         assertEq(vat.gem(ilk, me), 1000 ether);
-        assertEq(vat.dai(me), 0);  
+        assertEq(vat.dai(me), 0);
         vat.frob(ilk, me, me, me, 40 ether, 100 ether);
-        assertEq(vat.gem(ilk, me), 960 ether); 
-        assertEq(vat.dai(me), rad(100 ether));  
+        assertEq(vat.gem(ilk, me), 960 ether);
+        assertEq(vat.dai(me), rad(100 ether));
 
         pip.poke(bytes32(uint256(4 ether))); // Spot = $2
         spot.poke(ilk);          // Now unsafe
@@ -213,7 +213,7 @@ contract ClipperTest is DSTest {
         (, uint256 chop2,,,,) = dog.ilks(ilk);
         assertEq(chop, chop2);
     }
-    
+
     function test_kick() public {
         uint256 pos;
         uint256 tab;
@@ -241,7 +241,7 @@ contract ClipperTest is DSTest {
         assertEq(ink, 40 ether);
         assertEq(art, 100 ether);
 
-        Guy(ali).bark(dog, ilk, me);
+        Guy(ali).bark(dog, ilk, me, address(ali));
 
         assertEq(clip.kicks(), 1);
         (pos, tab, lot, usr, tic, top) = clip.sales(1);
@@ -282,7 +282,7 @@ contract ClipperTest is DSTest {
 
         assertEq(vat.dai(bob), rad(1000 ether));
 
-        Guy(bob).bark(dog, ilk, me);
+        Guy(bob).bark(dog, ilk, me, address(bob));
 
         assertEq(clip.kicks(), 2);
         (pos, tab, lot, usr, tic, top) = clip.sales(2);
@@ -324,8 +324,8 @@ contract ClipperTest is DSTest {
     }
 
     function try_bark(bytes32 ilk, address urn) internal returns (bool ok) {
-        string memory sig = "bark(bytes32,address)";
-        (ok,) = address(dog).call(abi.encodeWithSignature(sig, ilk, urn));
+        string memory sig = "bark(bytes32,address,address)";
+        (ok,) = address(dog).call(abi.encodeWithSignature(sig, ilk, urn, address(this)));
     }
 
     function test_bark_leaves_dust() public {
@@ -391,7 +391,7 @@ contract ClipperTest is DSTest {
         dog.file(ilk, "hole", mul(80 ether + 1, rate)); // Makes room = 80 WAD + 1 wei in normalized debt
         dog.file(ilk, "chop", 1 ether);                 // 0% chop (for precise calculations)
         vat.file(ilk, "dust", mul(20 ether, rate));     // $20 in normalized debt (multiplied by rate for testing)
-        
+
         assertEq(clip.kicks(), 0);
         (pos, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
@@ -430,7 +430,7 @@ contract ClipperTest is DSTest {
         (,,, uint256 dirt,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
-        dog.bark(ilk, me);
+        dog.bark(ilk, me, address(this));
 
         (, uint256 tab,,,,) = clip.sales(1);
 
@@ -463,7 +463,7 @@ contract ClipperTest is DSTest {
         pip2.poke(bytes32(uint256(4 ether))); // Spot = $2
         spot.poke(ilk2);
 
-        dog.bark(ilk2, me);
+        dog.bark(ilk2, me, address(this));
 
         (, uint256 tab2,,,,) = clip2.sales(1);
 
@@ -484,7 +484,7 @@ contract ClipperTest is DSTest {
         (,uint256 chop,, uint256 dirt,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
-        dog.bark(ilk, me);
+        dog.bark(ilk, me, address(this));
 
         (, uint256 tab, uint256 lot,,,) = clip.sales(1);
 
@@ -511,7 +511,7 @@ contract ClipperTest is DSTest {
         (,uint256 chop,, uint256 dirt,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
-        dog.bark(ilk, me);
+        dog.bark(ilk, me, address(this));
 
         (, uint256 tab, uint256 lot,,,) = clip.sales(1);
 
@@ -563,7 +563,7 @@ contract ClipperTest is DSTest {
         assertEq(usr, address(0));
         assertEq(uint256(tic), 0);
         assertEq(top, 0);
-    }   
+    }
 
     function test_take_at_tab() public takeSetup {
         // Bid so owe (= 22 * 5 = 110 RAD) == tab (= 110 RAD)
@@ -587,7 +587,7 @@ contract ClipperTest is DSTest {
         assertEq(usr, address(0));
         assertEq(uint256(tic), 0);
         assertEq(top, 0);
-    }   
+    }
 
     function test_take_under_tab() public takeSetup {
         // Bid so owe (= 11 * 5 = 55 RAD) < tab (= 110 RAD)
@@ -606,12 +606,12 @@ contract ClipperTest is DSTest {
         // Assert auction DOES NOT end
         (uint256 pos, uint256 tab, uint256 lot, address usr, uint256 tic, uint256 top) = clip.sales(1);
         assertEq(pos, 0);
-        assertEq(tab, rad(55 ether));  // 110 - 5 * 11 
+        assertEq(tab, rad(55 ether));  // 110 - 5 * 11
         assertEq(lot, 29 ether);       // 40 - 11
         assertEq(usr, me);
         assertEq(uint256(tic), now);
         assertEq(top, ray(5 ether));
-    }   
+    }
 
     function testFail_take_bid_too_low() public takeSetup {
         // Bid so max (= 4) < price (= top = 5) (fails with "Clipper/too-expensive")
@@ -622,7 +622,7 @@ contract ClipperTest is DSTest {
             who: address(ali),
             data: ""
         });
-    }   
+    }
 
     function testFail_take_bid_creates_dust() public takeSetup {
         // Bid so owe (= (22 - 1wei) * 5 = 110 RAD - 1) < tab (= 110 RAD) (fails with "Clipper/dust")
@@ -633,7 +633,7 @@ contract ClipperTest is DSTest {
             who: address(ali),
             data: ""
         });
-    }   
+    }
 
     function test_take_multiple_bids_different_prices() public takeSetup {
         uint256 pos;
@@ -642,11 +642,11 @@ contract ClipperTest is DSTest {
         address usr;
         uint96  tic;
         uint256 top;
-        
+
         // Bid so owe (= 10 * 5 = 50 RAD) < tab (= 110 RAD)
         Guy(ali).take({
             id:  1,
-            amt: 10 ether,     
+            amt: 10 ether,
             max: ray(5 ether),
             who: address(ali),
             data: ""
@@ -659,18 +659,18 @@ contract ClipperTest is DSTest {
         // Assert auction DOES NOT end
         (pos, tab, lot, usr, tic, top) = clip.sales(1);
         assertEq(pos, 0);
-        assertEq(tab, rad(60 ether));  // 110 - 5 * 10 
+        assertEq(tab, rad(60 ether));  // 110 - 5 * 10
         assertEq(lot, 30 ether);       // 40 - 10
         assertEq(usr, me);
         assertEq(uint256(tic), now);
         assertEq(top, ray(5 ether));
 
-        hevm.warp(now + 30); 
+        hevm.warp(now + 30);
 
         uint256 price = clip.calc().price(top, now - tic);
         Guy(bob).take({
             id:  1,
-            amt: 30 ether,     // Buy the rest of the lot 
+            amt: 30 ether,     // Buy the rest of the lot
             max: ray(4 ether), // 5 * 0.99 ** 30 = 3.698501866941401 RAY => max > price
             who: address(bob),
             data: ""
@@ -691,11 +691,11 @@ contract ClipperTest is DSTest {
 
         uint256 lotReturn = 30 ether - expectedGem;         // lot - loaf.tab / max = 15
         assertEq(vat.gem(ilk, me), 960 ether + lotReturn);  // Collateral returned (10 WAD)
-    } 
+    }
 
     function auctionResetSetup(uint256 tau) internal {
         LinearDecrease calc = new LinearDecrease();
-        calc.file(bytes32("tau"), tau);       // tau hours till zero is reached (used to test tail)  
+        calc.file(bytes32("tau"), tau);       // tau hours till zero is reached (used to test tail)
 
         vat.file(ilk, "dust", rad(20 ether)); // $20 dust
 
@@ -705,7 +705,7 @@ contract ClipperTest is DSTest {
         clip.file("tail", 3600);              // 1 hour before reset
 
         assertEq(clip.kicks(), 0);
-        dog.bark(ilk, me);
+        dog.bark(ilk, me, address(this));
         assertEq(clip.kicks(), 1);
     }
 
@@ -715,50 +715,50 @@ contract ClipperTest is DSTest {
     }
 
     function test_auction_reset_tail() public {
-        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail) 
+        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail)
 
         pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
 
         (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
         assertEq(uint256(ticBefore), startTime);
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
-        
+
         hevm.warp(startTime + 3600 seconds);
         assertTrue(!clip.needsRedo(1));
         assertTrue(!try_redo(1));
         hevm.warp(startTime + 3601 seconds);
         assertTrue( clip.needsRedo(1));
         assertTrue( try_redo(1));
-        
+
         (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
         assertEq(uint256(ticAfter), startTime + 3601 seconds);     // (now)
         assertEq(topAfter, ray(3.75 ether)); // $3 spot + 25% buffer = $5 (used most recent OSM price)
     }
 
     function test_auction_reset_cusp() public {
-        auctionResetSetup(1 hours); // 1 hour till zero is reached (used to test cusp) 
+        auctionResetSetup(1 hours); // 1 hour till zero is reached (used to test cusp)
 
         pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
 
         (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
         assertEq(uint256(ticBefore), startTime);
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
-        
+
         hevm.warp(startTime + 1800 seconds);
         assertTrue(!clip.needsRedo(1));
         assertTrue(!try_redo(1));
         hevm.warp(startTime + 1801 seconds);
         assertTrue( clip.needsRedo(1));
         assertTrue( try_redo(1));
-        
+
         (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
         assertEq(uint256(ticAfter), startTime + 1801 seconds);     // (now)
         assertEq(topAfter, ray(3.75 ether)); // $3 spot + 25% buffer = $3.75 (used most recent OSM price)
     }
 
     function test_auction_reset_tail_twice() public {
-        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail) 
-        
+        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail)
+
         hevm.warp(startTime + 3601 seconds);
         clip.redo(1);
 
@@ -766,8 +766,8 @@ contract ClipperTest is DSTest {
     }
 
     function test_auction_reset_cusp_twice() public {
-        auctionResetSetup(1 hours); // 1 hour till zero is reached (used to test cusp) 
-        
+        auctionResetSetup(1 hours); // 1 hour till zero is reached (used to test cusp)
+
         hevm.warp(startTime + 1801 seconds); // Price goes below 50% "cusp" after 30min01sec
         clip.redo(1);
 
@@ -809,7 +809,7 @@ contract ClipperTest is DSTest {
 
         clip.setBreaker(1);
 
-        dog.bark(ilk, me);
+        dog.bark(ilk, me, address(this));
     }
 
     // At a stopped == 1 we are ok to take
@@ -840,7 +840,7 @@ contract ClipperTest is DSTest {
     }
 
     function test_stopped_auction_reset_tail() public {
-        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail) 
+        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail)
 
         clip.setBreaker(1);
 
@@ -849,12 +849,12 @@ contract ClipperTest is DSTest {
         (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
         assertEq(uint256(ticBefore), startTime);
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
-        
+
         hevm.warp(startTime + 3600 seconds);
         assertTrue(!try_redo(1));
         hevm.warp(startTime + 3601 seconds);
         assertTrue( try_redo(1));
-        
+
         (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
         assertEq(uint256(ticAfter), startTime + 3601 seconds);     // (now)
         assertEq(topAfter, ray(3.75 ether)); // $3 spot + 25% buffer = $5 (used most recent OSM price)
@@ -863,14 +863,14 @@ contract ClipperTest is DSTest {
     function testFail_stopped_auction_reset_tail() public {
         clip.setBreaker(2);
 
-        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail) 
+        auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail)
 
         pip.poke(bytes32(uint256(3 ether))); // Spot = $1.50 (update price before reset is called)
 
         (,,,, uint96 ticBefore, uint256 topBefore) = clip.sales(1);
         assertEq(uint256(ticBefore), startTime);
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
-        
+
         hevm.warp(startTime + 3600 seconds);
         assertTrue(!try_redo(1));
         hevm.warp(startTime + 3601 seconds);

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -46,8 +46,8 @@ contract Guy {
         });
     }
 
-    function bark(Dog dog, bytes32 ilk, address urn, address guy) external {
-        dog.bark(ilk, urn, guy);
+    function bark(Dog dog, bytes32 ilk, address urn, address usr) external {
+        dog.bark(ilk, urn, usr);
     }
 }
 

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -527,16 +527,16 @@ contract EndTest is DSTest {
 
         vat.file("gold", "spot", ray(1 ether)); // Now unsafe
 
-        uint256 id = dog.bark("gold", urn1);   
+        uint256 id = dog.bark("gold", urn1, address(this));
 
         uint256 tab1;
-        uint256 lot1;    
+        uint256 lot1;
         {
             uint256 pos1;
             address usr1;
             uint96  tic1;
-            uint256 top1; 
-            (pos1, tab1, lot1, usr1, tic1, top1) = gold.clip.sales(id);  
+            uint256 top1;
+            (pos1, tab1, lot1, usr1, tic1, top1) = gold.clip.sales(id);
             assertEq(pos1, 0);
             assertEq(tab1, art1 * rate * 1.1 ether / WAD); // tab uses chop
             assertEq(lot1, ink1);
@@ -544,7 +544,7 @@ contract EndTest is DSTest {
             assertEq(uint256(tic1), now);
             assertEq(uint256(top1), ray(6 ether));
         }
-                     
+
         assertEq(dog.Dirt(), tab1);
 
         {
@@ -564,20 +564,20 @@ contract EndTest is DSTest {
         assertEq(vat.sin(address(vow)),        art1 * rate); // From grab in dog.bark()
         assertEq(vat.vice(),                   art1 * rate); // From grab in dog.bark()
         assertEq(vat.debt(),                   art1 * rate); // From frob
-        assertEq(vat.dai(address(vow)),                  0); // vat.suck() hasn't been called 
+        assertEq(vat.dai(address(vow)),                  0); // vat.suck() hasn't been called
 
         end.snip("gold", id);
-   
+
         {
             uint256 pos2;
             uint256 tab2;
-            uint256 lot2; 
+            uint256 lot2;
             address usr2;
             uint96  tic2;
-            uint256 top2; 
-            (pos2, tab2, lot2, usr2, tic2, top2) = gold.clip.sales(id);  
+            uint256 top2;
+            (pos2, tab2, lot2, usr2, tic2, top2) = gold.clip.sales(id);
             assertEq(pos2,          0);
-            assertEq(tab2,          0); 
+            assertEq(tab2,          0);
             assertEq(lot2,          0);
             assertEq(usr2,  address(0));
             assertEq(uint256(tic2), 0);
@@ -586,7 +586,7 @@ contract EndTest is DSTest {
 
         assertEq(dog.Dirt(),                            0); // From clip.yank()
         assertEq(vat.gem("gold", address(gold.clip)),   0); // From clip.yank()
-        assertEq(vat.gem("gold", address(end)),         0); // From grab in end.snip() 
+        assertEq(vat.gem("gold", address(end)),         0); // From grab in end.snip()
         assertEq(vat.sin(address(vow)),       art1 * rate); // From grab in dog.bark()
         assertEq(vat.vice(),                  art1 * rate); // From grab in dog.bark()
         assertEq(vat.debt(),           tab1 + art1 * rate); // From frob and suck


### PR DESCRIPTION
Overloads the bark function so that a keeper can send the rewards to a different address.