### PR TITLE
LIQ-2.0 20210114 updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 build  :; dapp --use solc:0.6.11 build
 clean  :; dapp clean
-test   :; dapp --use solc:0.6.11 test
+test   :; dapp --use solc:0.6.11 test -v

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,3 @@
-remappings=ds-test/=lib/ds-test/src/ ds-token/=lib/ds-token/src/ ds-note/=lib/ds-token/lib/ds-stop/lib/ds-note/src/ ds-value/=lib/ds-value/src/ erc20/=lib/ds-token/lib/erc20/src/ ds-math/=lib/ds-token/lib/ds-math/src/ ds-stop/=lib/ds-token/lib/ds-stop/src/ ds-thing/=lib/ds-value/lib/ds-thing/src/ ds-auth/=lib/ds-token/lib/ds-stop/lib/ds-auth/src/
-opts=--combined-json=abi,bin,bin-runtime,srcmap,srcmap-runtime,ast
-files=$$(find src -type f -name '*.sol')
-
-ls:
-	echo ${files}
-
-clean:
-	rm -rf out/
-
-build: clean
-	mkdir -p out/
-	solc --overwrite ${remappings} ${opts} /=/ ${files} > out/dss.json
-
-test: build
-	hevm dapp-test --json-file out/dss.json
+build  :; dapp --use solc:0.6.11 build
+clean  :; dapp clean
+test   :; dapp --use solc:0.6.11 test

--- a/src/abaci.sol
+++ b/src/abaci.sol
@@ -40,6 +40,8 @@ contract LinearDecrease is Abacus {
     event Rely(address indexed usr);
     event Deny(address indexed usr);
 
+    event FileUint256(bytes32 indexed what, uint256 data);
+
     // --- Init ---
     constructor() public {
         wards[msg.sender] = 1;
@@ -50,6 +52,7 @@ contract LinearDecrease is Abacus {
     function file(bytes32 what, uint256 data) external auth {
         if (what ==  "tau") tau = data;
         else revert("LinearDecrease/file-unrecognized-param");
+        emit FileUint256(what, data);
     }
 
     // --- Math ---
@@ -91,6 +94,8 @@ contract StairstepExponentialDecrease is Abacus {
     event Rely(address indexed usr);
     event Deny(address indexed usr);
 
+    event FileUint256(bytes32 indexed what, uint256 data);
+
     // --- Init ---
     constructor() public {
         wards[msg.sender] = 1;
@@ -104,6 +109,7 @@ contract StairstepExponentialDecrease is Abacus {
         if      (what ==  "cut") require((cut = data) <= RAY, "StairstepExponentialDecrease/cut-gt-RAY");
         else if (what == "step") step = data;
         else revert("StairstepExponentialDecrease/file-unrecognized-param");
+        emit FileUint256(what, data);
     }
 
     // --- Math ---

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -120,7 +120,7 @@ contract Clipper {
     );
 
     event SetBreaker(uint256 level);
-    event Yank();
+    event Yank(uint256 id);
 
     // --- Init ---
     constructor(address vat_, address spot_, address dog_, bytes32 ilk_) public {
@@ -367,7 +367,6 @@ contract Clipper {
         dog.digs(ilk, sales[id].tab);
         vat.flux(ilk, address(this), msg.sender, sales[id].lot);
         _remove(id);
-        // TODO: add id?
-        emit Yank();
+        emit Yank(id);
     }
 }

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -73,7 +73,7 @@ contract Clipper {
     struct Sale {
         uint256 pos;  // Index in active array
         uint256 tab;  // Dai to raise       [rad]
-        uint256 lot;  // ETH to sell        [wad]
+        uint256 lot;  // collateral to sell [wad]
         address usr;  // Liquidated CDP
         uint96  tic;  // Auction start time
         uint256 top;  // Starting price     [ray]
@@ -85,7 +85,7 @@ contract Clipper {
     // Levels for circuit breaker
     // 0: no breaker
     // 1: no new kick()
-    // 2: no new warm() or take()
+    // 2: no new redo() or take()
     uint256 public stopped = 0;
 
     // --- Events ---
@@ -168,7 +168,7 @@ contract Clipper {
     uint256 constant BLN = 10 ** 9;
 
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        return x <= y ? x : y;
+        z = x <= y ? x : y;
     }
     function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x - y) <= x);
@@ -192,11 +192,11 @@ contract Clipper {
                   address usr   // Liquidated CDP
     ) external auth isStopped(1) returns (uint256 id) {
         // Input validation
-        require(tab  >          0, "Clipper/zero-tab");
-        require(lot  >          0, "Clipper/zero-lot");
-        require(usr != address(0), "Clipper/zero-usr");
+        require(tab    >           0, "Clipper/zero-tab");
+        require(lot    >           0, "Clipper/zero-lot");
+        require(usr   !=  address(0), "Clipper/zero-usr");
+        require(kicks  < uint256(-1), "Clipper/overflow");
 
-        require(kicks < uint256(-1), "Clipper/overflow");
         id = ++kicks;
         active.push(id);
 
@@ -205,7 +205,7 @@ contract Clipper {
         sales[id].tab = tab;
         sales[id].lot = lot;
         sales[id].usr = usr;
-        sales[id].tic = uint96(now);
+        sales[id].tic = uint96(block.timestamp);
 
         // Could get this from rmul(Vat.ilks(ilk).spot, Spotter.mat()) instead,
         // but if mat has changed since the last poke, the resulting value will
@@ -225,12 +225,12 @@ contract Clipper {
         require(sale.usr != address(0), "Clipper/not-running-auction");
 
         // Compute current price [ray]
-        uint256 price = calc.price(sale.top, sub(now, sale.tic));
+        uint256 price = calc.price(sale.top, sub(block.timestamp, sale.tic));
 
         // Check that auction needs reset
         require(done(sale, price), "Clipper/cannot-reset");
 
-        sales[id].tic = uint96(now);
+        sales[id].tic = uint96(block.timestamp);
 
         // Could get this from rmul(Vat.ilks(ilk).spot, Spotter.mat()) instead, but if mat has changed since the
         // last poke, the resulting value will be incorrect
@@ -238,6 +238,8 @@ contract Clipper {
         (bytes32 val, bool has) = pip.peek();
         require(has, "Clipper/invalid-price");
         sales[id].top = rmul(rdiv(mul(uint256(val), BLN), spot.par()), buf);
+
+        // TODO: missing incentive
 
         emit Redo(id, sales[id].top, sales[id].tab, sales[id].lot, sales[id].usr);
     }
@@ -254,7 +256,7 @@ contract Clipper {
         require(sale.usr != address(0), "Clipper/not-running-auction");
 
         // Compute current price [ray]
-        uint256 price = calc.price(sale.top, sub(now, sale.tic));
+        uint256 price = calc.price(sale.top, sub(block.timestamp, sale.tic));
 
         // Check that auction doesn't need reset
         require(!done(sale, price), "Clipper/needs-reset");
@@ -272,6 +274,7 @@ contract Clipper {
         if (owe >= sale.tab) {
             owe = sale.tab;       // owe' <= owe
             slice = owe / price;  // Adjust slice; slice' = owe' / price <= owe / price == slice <= lot
+            // TODO check that this doesn't violate max from user
             sale.tab = 0;         // Zero tab left, auction will be deleted
         } else {  // owe < sale.tab
             // Calculate remaining tab after operation
@@ -281,12 +284,14 @@ contract Clipper {
         }
 
         // Calculate remaining lot after operation
+        // TODO: could we end up with 1 wei rounding error?
         sale.lot = sale.lot - slice;  // safe because: slice <= lot
 
         // Send collateral to who
         vat.flux(ilk, address(this), who, slice);
 
         // Do external call (if defined)
+        // TODO: do we want to circuit break flash loans?
         if (data.length > 0) {
             ClipperCallee(who).clipperCall(owe, slice, data);
         }
@@ -340,14 +345,14 @@ contract Clipper {
         Sale memory sale = sales[id];
 
         // Compute current price [ray]
-        uint256 price = calc.price(sale.top, sub(now, sale.tic));
+        uint256 price = calc.price(sale.top, sub(block.timestamp, sale.tic));
 
         return sale.usr != address(0) && done(sale, price);
     }
 
     // Internally returns boolean for if an auction needs a redo
     function done(Sale memory sale, uint256 price) internal view returns (bool) {
-        return (sub(now, sale.tic) > tail || rdiv(price, sale.top) < cusp);
+        return (sub(block.timestamp, sale.tic) > tail || rdiv(price, sale.top) < cusp);
     }
 
     // --- Shutdown ---
@@ -362,6 +367,7 @@ contract Clipper {
         dog.digs(ilk, sales[id].tab);
         vat.flux(ilk, address(this), msg.sender, sales[id].lot);
         _remove(id);
+        // TODO: add id?
         emit Yank();
     }
 }

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -274,7 +274,6 @@ contract Clipper {
         if (owe >= sale.tab) {
             owe = sale.tab;       // owe' <= owe
             slice = owe / price;  // Adjust slice; slice' = owe' / price <= owe / price == slice <= lot
-            // TODO check that this doesn't violate max from user
             sale.tab = 0;         // Zero tab left, auction will be deleted
         } else {  // owe < sale.tab
             // Calculate remaining tab after operation

--- a/src/dog.sol
+++ b/src/dog.sol
@@ -107,7 +107,7 @@ contract Dog {
     uint256 constant WAD = 10 ** 18;
 
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        if (x > y) { z = y; } else { z = x; }
+        z = x <= y ? x : y;
     }
     function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x + y) >= x);
@@ -118,7 +118,7 @@ contract Dog {
     function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require(y == 0 || (z = x * y) / y == x);
     }
-    function wmul(uint x, uint y) internal pure returns (uint z) {
+    function wmul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = mul(x, y) / WAD;
     }
 
@@ -147,7 +147,9 @@ contract Dog {
         emit FileIlkClip(ilk, what, clip);
     }
 
-    function chop(bytes32 ilk) external view returns (uint256) { return ilks[ilk].chop; }
+    function chop(bytes32 ilk) external view returns (uint256) {
+        return ilks[ilk].chop;
+    }
 
     // --- CDP Liquidation: all bark and no bite ---
     function bark(bytes32 ilk, address urn) external returns (uint256 id) {
@@ -171,6 +173,7 @@ contract Dog {
             // Verify there is room and it is not dusty
             require(room > 0 && room >= dust, "Dog/liquidation-limit-hit");
 
+            // uint256.max()/(RAD*WAD) = 115,792,089,237,316
             dart = min(art, mul(room, WAD) / rate / milk.chop);
 
             // Verify that CDP is not left in a dusty state
@@ -202,6 +205,7 @@ contract Dog {
             });
         }
 
+        // incentive to call bark()
         vat.suck(address(vow), msg.sender, add(milk.tip, wmul(due, milk.chip)));
 
         emit Bark(ilk, urn, dink, dart, due, milk.clip, id);


### PR DESCRIPTION
- updates some comments with
- fix Makefile
- adds missing events
- `now` to `block.timestamp`
- TODO
- [x] add yank id
- [ ] add incentive like `bark()` in `redo()`
- [ ] check the possibility of 1 wei rounding error
- [x] consider circuit breaking flash loans