### PR TITLE
Block take impersonation and implement approval

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -75,7 +75,7 @@ contract Clipper {
         address => mapping(
             address => bool
         )
-    ) public can;           // Owner => Allowed Owner => True/False
+    ) public can;           // Owner => Allowed User => True/False
 
     struct Sale {
         uint256 pos;  // Index in active array

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -992,7 +992,7 @@ contract ClipperTest is DSTest {
         assertEq(vat.gem(ilk, address(this)), preGemBalance + origLot);
     }
 
-    function testFail_take_impersonation() public takeSetup { // should fail, but works
+    function testFail_take_impersonation() public takeSetup {
         Guy che = new Guy(clip);
         che.take({
             id: 1,

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -987,4 +987,15 @@ contract ClipperTest is DSTest {
         // Assert transfer of gem.
         assertEq(vat.gem(ilk, address(this)), preGemBalance + origLot);
     }
+
+    function testFail_take_impersonation() public takeSetup { // should fail, but works
+        Guy che = new Guy(clip);
+        che.take({
+            id: 1,
+            amt: 99999999999999 ether,
+            max: ray(99999999999999 ether),
+            who: address(ali),
+            data: ""
+        });
+    }
 }

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -30,6 +30,10 @@ contract Guy {
         Vat(address(clip.vat())).hope(usr);
     }
 
+    function approve(address usr, bool ok) public {
+        clip.approve(usr, ok);
+    }
+
     function take(
         uint256 id,
         uint256 amt,
@@ -990,6 +994,19 @@ contract ClipperTest is DSTest {
 
     function testFail_take_impersonation() public takeSetup { // should fail, but works
         Guy che = new Guy(clip);
+        che.take({
+            id: 1,
+            amt: 99999999999999 ether,
+            max: ray(99999999999999 ether),
+            who: address(ali),
+            data: ""
+        });
+    }
+
+    function test_allowed_take_impersonation() public takeSetup {
+        Guy che = new Guy(clip);
+        Guy(ali).approve(address(che), true);
+
         che.take({
             id: 1,
             amt: 99999999999999 ether,


### PR DESCRIPTION
Add a simple approval system for takes. Assumes `take()` passes itself as a `who`, otherwise require `who` is an approved receiver. Adds test of approval.