### PR TITLE
fix: move incentive to kick() in redo() (SC-8390)

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -60,6 +60,7 @@ contract Clipper {
     VatLike  immutable public vat;   // Core CDP Engine
     SpotLike immutable public spot;  // Collateral price module
 
+    // TODO: do we want to make vow and dog immutable?
     address    public vow;   // Recipient of dai raised in auctions
     DogLike    public dog;   // Liquidation module
     AbacusLike public calc;  // Current price calculator
@@ -239,6 +240,7 @@ contract Clipper {
     }
 
     // Reset an auction
+    // TODO: should we add the reentrancy guard here?
     function redo(uint256 id, address kpr) external isStopped(2) {
         // Read auction data
         address usr = sales[id].usr;
@@ -338,6 +340,7 @@ contract Clipper {
             vat.flux(ilk, address(this), who, slice);
 
             // Do external call (if defined)
+            // TODO: do we want to do this with the dog too?
             if (data.length > 0 && address(vat) != who) {
                 ClipperCallee(who).clipperCall(msg.sender, owe, slice, data);
             }

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -338,7 +338,7 @@ contract Clipper {
             vat.flux(ilk, address(this), who, slice);
 
             // Do external call (if defined)
-            if (data.length > 0) {
+            if (data.length > 0 && address(vat) != who) {
                 ClipperCallee(who).clipperCall(msg.sender, owe, slice, data);
             }
         }

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -231,7 +231,9 @@ contract Clipper {
         sales[id].top = rmul(rdiv(mul(uint256(val), BLN), spot.par()), buf);
 
         // incentive to kick auction
-        vat.suck(address(vow), kpr, add(tip, wmul(tab, chip)));
+        if (tip > 0 || chip > 0) {
+            vat.suck(address(vow), kpr, add(tip, wmul(tab, chip)));
+        }
 
         emit Kick(id, sales[id].top, tab, lot, usr);
     }
@@ -239,8 +241,6 @@ contract Clipper {
     // Reset an auction
     function redo(uint256 id, address kpr) external isStopped(2) {
         // Read auction data
-        uint256 tab = sales[id].tab;
-        uint256 lot = sales[id].lot;
         address usr = sales[id].usr;
         uint96  tic = sales[id].tic;
         uint256 top = sales[id].top;
@@ -252,6 +252,8 @@ contract Clipper {
         (bool done, ) = status(tic, top);
         require(done, "Clipper/cannot-reset");
 
+        uint256 tab   = sales[id].tab;
+        uint256 lot   = sales[id].lot;
         sales[id].tic = uint96(block.timestamp);
 
         // Could get this from rmul(Vat.ilks(ilk).spot, Spotter.mat()) instead, but if mat has changed since the
@@ -264,7 +266,9 @@ contract Clipper {
         // TODO: have a test for dusty lot here
 
         // incentive to redo auction
-        vat.suck(address(vow), kpr, add(tip, wmul(tab, chip)));
+        if (tip > 0 || chip > 0) {
+            vat.suck(address(vow), kpr, add(tip, wmul(tab, chip)));
+        }
 
         emit Redo(id, top, tab, lot, usr);
     }

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -150,9 +150,10 @@ contract RedoGuy is Guy {
 
     constructor(Clipper clip_) Guy(clip_) public {}
 
-    function clipperCall(address sender, uint256 owe, uint256 slice, bytes calldata data)
-        external {
-        clip.redo(1);
+    function clipperCall(
+        address sender, uint256 owe, uint256 slice, bytes calldata data
+    ) external {
+        clip.redo(1, sender);
     }
 }
 
@@ -431,8 +432,6 @@ contract ClipperTest is DSTest {
         assertEq(ink, 0 ether);
         assertEq(art, 0 ether);
 
-//        (, uint256 rate,,,) = vat.ilks(ilk);
-//        uint owe = ((100 ether * rate) * 1.1 ether) / 1 ether; // (art * rate from initial frob with liquidation penalty)
         assertEq(vat.dai(bob), rad(1000 ether) + rad(100 ether) + tab * 0.02 ether / WAD); // Paid (tip + due * chip) amount of DAI for calling bark()
     }
 

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -344,7 +344,7 @@ contract ClipperTest is DSTest {
 
     function test_get_chop() public {
         uint256 chop = dog.chop(ilk);
-        (, uint256 chop2,,,,) = dog.ilks(ilk);
+        (, uint256 chop2,,) = dog.ilks(ilk);
         assertEq(chop, chop2);
     }
 
@@ -358,8 +358,8 @@ contract ClipperTest is DSTest {
         uint256 ink;
         uint256 art;
 
-        dog.file(ilk, "tip",  rad(100 ether)); // Flat fee of 100 DAI
-        dog.file(ilk, "chip", 0);              // No linear increase
+        clip.file("tip",  rad(100 ether)); // Flat fee of 100 DAI
+        clip.file("chip", 0);              // No linear increase
 
         assertEq(clip.kicks(), 0);
         (pos, tab, lot, usr, tic, top) = clip.sales(1);
@@ -411,8 +411,8 @@ contract ClipperTest is DSTest {
 
         clip.file(bytes32("buf"),  ray(1.25 ether)); // 25% Initial price buffer
 
-        dog.file(ilk, "tip",  rad(100 ether)); // Flat fee of 100 DAI
-        dog.file(ilk, "chip", 0.02 ether);     // Linear increase of 2% of tab
+        clip.file("tip",  rad(100 ether)); // Flat fee of 100 DAI
+        clip.file("chip", 0.02 ether);     // Linear increase of 2% of tab
 
         assertEq(vat.dai(bob), rad(1000 ether));
 
@@ -431,30 +431,30 @@ contract ClipperTest is DSTest {
         assertEq(ink, 0 ether);
         assertEq(art, 0 ether);
 
-        (, uint256 rate,,,) = vat.ilks(ilk);
-        uint due = 100 ether * rate; // (art * rate from initial frob)
-        assertEq(vat.dai(bob), rad(1000 ether) + rad(100 ether) + due * 0.02 ether / WAD); // Paid (tip + due * chip) amount of DAI for calling bark()
+//        (, uint256 rate,,,) = vat.ilks(ilk);
+//        uint owe = ((100 ether * rate) * 1.1 ether) / 1 ether; // (art * rate from initial frob with liquidation penalty)
+        assertEq(vat.dai(bob), rad(1000 ether) + rad(100 ether) + tab * 0.02 ether / WAD); // Paid (tip + due * chip) amount of DAI for calling bark()
     }
 
-    function try_kick(uint256 tab, uint256 lot, address usr) internal returns (bool ok) {
-        string memory sig = "kick(uint256,uint256,address)";
-        (ok,) = address(clip).call(abi.encodeWithSignature(sig, tab, lot, usr));
+    function try_kick(uint256 tab, uint256 lot, address usr, address kpr) internal returns (bool ok) {
+        string memory sig = "kick(uint256,uint256,address,address)";
+        (ok,) = address(clip).call(abi.encodeWithSignature(sig, tab, lot, usr, kpr));
     }
 
     function test_kick_basic() public {
-        assertTrue(try_kick(1 ether, 2 ether, address(1)));
+        assertTrue(try_kick(1 ether, 2 ether, address(1), address(this)));
     }
 
     function test_kick_zero_tab() public {
-        assertTrue(!try_kick(0, 2 ether, address(1)));
+        assertTrue(!try_kick(0, 2 ether, address(1), address(this)));
     }
 
     function test_kick_zero_lot() public {
-        assertTrue(!try_kick(1 ether, 0, address(1)));
+        assertTrue(!try_kick(1 ether, 0, address(1), address(this)));
     }
 
     function test_kick_zero_usr() public {
-        assertTrue(!try_kick(1 ether, 2 ether, address(0)));
+        assertTrue(!try_kick(1 ether, 2 ether, address(0), address(this)));
     }
 
     function try_bark(bytes32 ilk_, address urn_) internal returns (bool ok) {
@@ -643,7 +643,7 @@ contract ClipperTest is DSTest {
 
     function test_Hole_hole() public {
         assertEq(dog.Dirt(), 0);
-        (,,, uint256 dirt,,) = dog.ilks(ilk);
+        (,,, uint256 dirt) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me, address(this));
@@ -651,7 +651,7 @@ contract ClipperTest is DSTest {
         (, uint256 tab,,,,) = clip.sales(1);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt,,) = dog.ilks(ilk);
+        (,,, dirt) = dog.ilks(ilk);
         assertEq(dirt, tab);
 
         bytes32 ilk2 = "silver";
@@ -684,8 +684,8 @@ contract ClipperTest is DSTest {
         (, uint256 tab2,,,,) = clip2.sales(1);
 
         assertEq(dog.Dirt(), tab + tab2);
-        (,,, dirt,,) = dog.ilks(ilk);
-        (,,, uint256 dirt2,,) = dog.ilks(ilk2);
+        (,,, dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt2) = dog.ilks(ilk2);
         assertEq(dirt, tab);
         assertEq(dirt2, tab2);
     }
@@ -697,7 +697,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether);
 
         assertEq(dog.Dirt(), 0);
-        (,uint256 chop,, uint256 dirt,,) = dog.ilks(ilk);
+        (,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me, address(this));
@@ -713,7 +713,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether - tab * WAD / rate / chop);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt,,) = dog.ilks(ilk);
+        (,,, dirt) = dog.ilks(ilk);
         assertEq(dirt, tab);
     }
 
@@ -724,7 +724,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether);
 
         assertEq(dog.Dirt(), 0);
-        (,uint256 chop,, uint256 dirt,,) = dog.ilks(ilk);
+        (,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me, address(this));
@@ -740,7 +740,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether - tab * WAD / rate / chop);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt,,) = dog.ilks(ilk);
+        (,,, dirt) = dog.ilks(ilk);
         assertEq(dirt, tab);
     }
 
@@ -965,9 +965,9 @@ contract ClipperTest is DSTest {
         assertEq(clip.kicks(), 1);
     }
 
-    function try_redo(uint256 id) internal returns (bool ok) {
-        string memory sig = "redo(uint256)";
-        (ok,) = address(clip).call(abi.encodeWithSignature(sig, id));
+    function try_redo(uint256 id, address kpr) internal returns (bool ok) {
+        string memory sig = "redo(uint256,address)";
+        (ok,) = address(clip).call(abi.encodeWithSignature(sig, id, kpr));
     }
 
     function test_auction_reset_tail() public {
@@ -981,10 +981,10 @@ contract ClipperTest is DSTest {
 
         hevm.warp(startTime + 3600 seconds);
         assertTrue(!clip.needsRedo(1));
-        assertTrue(!try_redo(1));
+        assertTrue(!try_redo(1, address(this)));
         hevm.warp(startTime + 3601 seconds);
-        assertTrue( clip.needsRedo(1));
-        assertTrue( try_redo(1));
+        assertTrue(clip.needsRedo(1));
+        assertTrue(try_redo(1, address(this)));
 
         (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
         assertEq(uint256(ticAfter), startTime + 3601 seconds);     // (now)
@@ -1002,10 +1002,10 @@ contract ClipperTest is DSTest {
 
         hevm.warp(startTime + 1800 seconds);
         assertTrue(!clip.needsRedo(1));
-        assertTrue(!try_redo(1));
+        assertTrue(!try_redo(1, address(this)));
         hevm.warp(startTime + 1801 seconds);
-        assertTrue( clip.needsRedo(1));
-        assertTrue( try_redo(1));
+        assertTrue(clip.needsRedo(1));
+        assertTrue(try_redo(1, address(this)));
 
         (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
         assertEq(uint256(ticAfter), startTime + 1801 seconds);     // (now)
@@ -1016,23 +1016,23 @@ contract ClipperTest is DSTest {
         auctionResetSetup(10 hours); // 10 hours till zero is reached (used to test tail)
 
         hevm.warp(startTime + 3601 seconds);
-        clip.redo(1);
+        clip.redo(1, address(this));
 
-        assertTrue(!try_redo(1));
+        assertTrue(!try_redo(1, address(this)));
     }
 
     function test_auction_reset_cusp_twice() public {
         auctionResetSetup(1 hours); // 1 hour till zero is reached (used to test cusp)
 
         hevm.warp(startTime + 1801 seconds); // Price goes below 50% "cusp" after 30min01sec
-        clip.redo(1);
+        clip.redo(1, address(this));
 
-        assertTrue(!try_redo(1));
+        assertTrue(!try_redo(1, address(this)));
     }
 
     function test_redo_zero_usr() public {
         // Can't reset a non-existent auction.
-        assertTrue(!try_redo(1));
+        assertTrue(!try_redo(1, address(this)));
     }
 
     function test_setBreaker() public {
@@ -1107,9 +1107,9 @@ contract ClipperTest is DSTest {
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
 
         hevm.warp(startTime + 3600 seconds);
-        assertTrue(!try_redo(1));
+        assertTrue(!try_redo(1, address(this)));
         hevm.warp(startTime + 3601 seconds);
-        assertTrue( try_redo(1));
+        assertTrue(try_redo(1, address(this)));
 
         (,,,, uint96 ticAfter, uint256 topAfter) = clip.sales(1);
         assertEq(uint256(ticAfter), startTime + 3601 seconds);     // (now)
@@ -1128,9 +1128,9 @@ contract ClipperTest is DSTest {
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
 
         hevm.warp(startTime + 3600 seconds);
-        assertTrue(!try_redo(1));
+        assertTrue(!try_redo(1, address(this)));
         hevm.warp(startTime + 3601 seconds);
-        assertTrue( try_redo(1));
+        assertTrue(try_redo(1, address(this)));
     }
 
     function test_Clipper_yank() public takeSetup {
@@ -1153,7 +1153,7 @@ contract ClipperTest is DSTest {
 
         // Assert that callback to clear dirt was successful.
         assertEq(dog.Dirt(), 0);
-        (,,, uint256 dirt,,) = dog.ilks(ilk);
+        (,,, uint256 dirt) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         // Assert transfer of gem.

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -178,6 +178,7 @@ contract EndTest is DSTest {
         cat.file("box", rad((10 ether) * MLN));
 
         Clipper clip = new Clipper(address(vat), address(spot), address(dog), name);
+        vat.rely(address(clip));
         vat.hope(address(clip));
         clip.rely(address(end));
         clip.rely(address(dog));


### PR DESCRIPTION
This fixes a bug where we missed incentives in `redo()` by moving incentives into the `clip.kick()` and `clip.redo()`.  The variables `chip` and `tip` were also moved to each ilk's respective `Clipper`.

The biggest methodology change is that rather than calculating the `tip` and `chip` on the normalized debt owed, we are calculating it on the entire `tab`.  Calculating these values on the normalized debt in `kick()` would require passing the normalized debt to `kick()` and then storing it.  We would then need to store the original `tab` in order to calculate the ratio of initial tab to partial tab later in the `redo()` so that we could only incentivize the `redo()` on the leftover partial liquidation.

Rather than doing all of that, I'm suggesting we simply use the `tab` to calculate incentives. 