### PR TITLE
Prevent take impersonation.

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -75,7 +75,7 @@ contract Clipper {
         address => mapping(
             address => bool
         )
-    ) public can;           // Owner => Allowed Owner => True/False
+    ) public can;           // Owner => Allowed User => True/False
 
     struct Sale {
         uint256 pos;  // Index in active array

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -251,7 +251,7 @@ contract Clipper {
     function take(uint256 id,           // Auction id
                   uint256 amt,          // Upper limit on amount of collateral to buy  [wad]
                   uint256 max,          // Maximum acceptable price (DAI / collateral) [ray]
-                  address who,          // Receiver of collateral, payer of DAI, and external call address
+                  address who,          // Receiver of collateral, and external call address
                   bytes calldata data   // Data to pass in external call; if length 0, no call is done
     ) external lock isStopped(2) {
 

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -307,7 +307,7 @@ contract Clipper {
             }
         }
 
-        // Get DAI from who address
+        // Get DAI from caller
         vat.move(msg.sender, vow, owe);
 
         // Removes Dai out for liquidation from accumulator

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -85,14 +85,14 @@ contract Trader {
         });
     }
 
-    function clipperCall(address who, uint256 owe, uint256 slice, bytes calldata data)
+    function clipperCall(address sender, uint256 owe, uint256 slice, bytes calldata data)
         external {
         goldJoin.exit(address(this), slice);
         gold.approve(address(exchange));
         exchange.sellGold(slice);
         dai.approve(address(daiJoin));
         vat.hope(address(clip));
-        daiJoin.join(address(this), owe / 1E27);
+        daiJoin.join(sender, owe / 1E27);
     }
 }
 

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -992,7 +992,7 @@ contract ClipperTest is DSTest {
         assertEq(vat.gem(ilk, address(this)), preGemBalance + origLot);
     }
 
-    function testFail_take_impersonation() public takeSetup { // should fail, but works
+    function testFail_take_impersonation() public takeSetup {
         Guy che = new Guy(clip);
         che.take({
             id: 1,

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -134,7 +134,7 @@ contract BadGuy is Guy {
 
     constructor(Clipper clip_) Guy(clip_) public {}
 
-    function clipperCall(uint256 owe, uint256 slice, bytes calldata data)
+    function clipperCall(address sender, uint256 owe, uint256 slice, bytes calldata data)
         external {
         clip.take({ // attempt reentrancy
             id: 1,
@@ -150,7 +150,7 @@ contract RedoGuy is Guy {
 
     constructor(Clipper clip_) Guy(clip_) public {}
 
-    function clipperCall(uint256 owe, uint256 slice, bytes calldata data)
+    function clipperCall(address sender, uint256 owe, uint256 slice, bytes calldata data)
         external {
         clip.redo(1);
     }

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -987,4 +987,15 @@ contract ClipperTest is DSTest {
         // Assert transfer of gem.
         assertEq(vat.gem(ilk, address(this)), preGemBalance + origLot);
     }
+
+    function testFail_take_impersonation() public takeSetup { // should fail, but works
+        Guy che = new Guy(clip);
+        che.take({
+            id: 1,
+            amt: 99999999999999 ether,
+            max: ray(99999999999999 ether),
+            who: address(ali),
+            data: ""
+        });
+    }
 }

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -30,10 +30,6 @@ contract Guy {
         Vat(address(clip.vat())).hope(usr);
     }
 
-    function approve(address usr, bool ok) public {
-        clip.approve(usr, ok);
-    }
-
     function take(
         uint256 id,
         uint256 amt,
@@ -994,19 +990,6 @@ contract ClipperTest is DSTest {
 
     function testFail_take_impersonation() public takeSetup {
         Guy che = new Guy(clip);
-        che.take({
-            id: 1,
-            amt: 99999999999999 ether,
-            max: ray(99999999999999 ether),
-            who: address(ali),
-            data: ""
-        });
-    }
-
-    function test_allowed_take_impersonation() public takeSetup {
-        Guy che = new Guy(clip);
-        Guy(ali).approve(address(che), true);
-
         che.take({
             id: 1,
             amt: 99999999999999 ether,

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -30,6 +30,10 @@ contract Guy {
         Vat(address(clip.vat())).hope(usr);
     }
 
+    function approve(address usr, bool ok) public {
+        clip.approve(usr, ok);
+    }
+
     function take(
         uint256 id,
         uint256 amt,
@@ -990,6 +994,19 @@ contract ClipperTest is DSTest {
 
     function testFail_take_impersonation() public takeSetup { // should fail, but works
         Guy che = new Guy(clip);
+        che.take({
+            id: 1,
+            amt: 99999999999999 ether,
+            max: ray(99999999999999 ether),
+            who: address(ali),
+            data: ""
+        });
+    }
+
+    function test_allowed_take_impersonation() public takeSetup {
+        Guy che = new Guy(clip);
+        Guy(ali).approve(address(che), true);
+
         che.take({
             id: 1,
             amt: 99999999999999 ether,

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -1163,4 +1163,15 @@ contract ClipperTest is DSTest {
             data: "hey"
         });
     }
+
+    function testFail_take_impersonation() public takeSetup { // should fail, but works
+        Guy che = new Guy(clip);
+        che.take({
+            id: 1,
+            amt: 99999999999999 ether,
+            max: ray(99999999999999 ether),
+            who: address(ali),
+            data: ""
+        });
+    }
 }


### PR DESCRIPTION
Alternative solution to preventing take impersonation.

I just realized that there are no tests of a `clipperCall()` implementation, so we will need to add one depending on the implementation we go with.