### PR TITLE
dog.bark: simplify calculation of dart

### DIFF
--- a/src/dog.sol
+++ b/src/dog.sol
@@ -120,6 +120,9 @@ contract Dog {
     function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require(y == 0 || (z = x * y) / y == x);
     }
+    function wdiv(uint x, uint y) internal pure returns (uint z) {
+        z = mul(x, WAD) / y;
+    }
 
     // --- Administration ---
     function file(bytes32 what, address data) external auth {
@@ -170,13 +173,9 @@ contract Dog {
             // Verify there is room and it is not dusty
             require(room > 0 && room >= dust, "Dog/liquidation-limit-hit");
 
-            // uint256.max()/(RAD*WAD) = 115,792,089,237,316
-            dart = min(art, mul(room, WAD) / rate / milk.chop);
-
-            if (mul(art - dart, rate) < dust) {
-                // avoid leaving a dusty vault to prevent unliquidatable vaults
-                dart = art;
-            }
+            uint256 tab = mul(art, rate);
+            uint256 choppedRoom = wdiv(room, milk.chop);
+            dart = choppedRoom > sub(tab, dust) ? art : choppedRoom / rate;
         }
 
         uint256 dink = mul(ink, dart) / art;

--- a/src/test/dog.t.sol
+++ b/src/test/dog.t.sol
@@ -78,8 +78,7 @@ contract DogTest is DSTest {
         dog.bark(ilk, usr, address(this));
     }
 
-    // currently, dog.bark doesn't check if a vault is unliquidatable
-    function test_bark_unliquidatable_vault() public {
+    function testFail_bark_unliquidatable_vault() public {
         uint256 dust = 200;
         vat.file(ilk, "dust", dust * RAD);
         setUrn(1, (dust / 2) * WAD);
@@ -87,7 +86,7 @@ contract DogTest is DSTest {
         dog.bark(ilk, usr, address(this));
     }
 
-    function test_bark_over_ilk_hole_under_ilk_hole_plus_dust() public {
+    function test_bark_over_ilk_hole_under_dust() public {
         uint256 dust = 200;
         vat.file(ilk, "dust", dust * RAD);
         uint256 hole = 5 * THOUSAND;
@@ -99,7 +98,7 @@ contract DogTest is DSTest {
         assertEq(art, 0);
     }
 
-    function test_bark_over_Hole_under_Hole_plus_dust() public {
+    function test_bark_over_Hole_under_dust() public {
         uint256 dust = 200;
         vat.file(ilk, "dust", dust * RAD);
         uint256 Hole = 5 * THOUSAND;
@@ -120,7 +119,7 @@ contract DogTest is DSTest {
         dog.bark(ilk, usr, address(this));
         assertTrue(!isDusty());
         (, uint256 art) = vat.urns(ilk, usr);
-        assertEq(art, dust * WAD);
+        assertEq(art, 0);
     }
 
     function test_bark_equals_Hole_plus_dust() public {
@@ -132,6 +131,30 @@ contract DogTest is DSTest {
         dog.bark(ilk, usr, address(this));
         assertTrue(!isDusty());
         (, uint256 art) = vat.urns(ilk, usr);
-        assertEq(art, dust * WAD);
+        assertEq(art, 0);
+    }
+
+    function test_bark_over_ilk_hole_plus_dust() public {
+        uint256 dust = 200;
+        vat.file(ilk, "dust", dust * RAD);
+        uint256 hole = 5 * THOUSAND;
+        dog.file(ilk, "hole", hole * RAD);
+        setUrn(WAD, hole * WAD * WAD / dog.chop(ilk) + dust * WAD + 1);
+        dog.bark(ilk, usr, address(this));
+        assertTrue(!isDusty());
+        (, uint256 art) = vat.urns(ilk, usr);
+        assertEq(art, dust * WAD + 1);
+    }
+
+    function test_bark_over_Hole_plus_dust() public {
+        uint256 dust = 200;
+        vat.file(ilk, "dust", dust * RAD);
+        uint256 Hole = 5 * THOUSAND;
+        dog.file("Hole", Hole * RAD);
+        setUrn(WAD, Hole * WAD * WAD / dog.chop(ilk) + dust * WAD + 1);
+        dog.bark(ilk, usr, address(this));
+        assertTrue(!isDusty());
+        (, uint256 art) = vat.urns(ilk, usr);
+        assertEq(art, dust * WAD + 1);
     }
 }


### PR DESCRIPTION
Since dust is now a factor in the calculation of `dart`, this PR makes this process more straightforward by merging two calculations into one. Basically, in order to liquidate a whole vault, it must be true that

    room / chop > tab - dust

That is, the chop-adjusted room has to be bigger than the vault, excluding its dust value.

While maintaining similar gas expenditures, this PR not only makes the code more maintainable, but also fails to create a liquidation if the vault is unliquidatable.