### PR TITLE
feat: added step to dog for LR != CR support

### DIFF
--- a/src/dog.sol
+++ b/src/dog.sol
@@ -62,6 +62,7 @@ contract Dog {
     // --- Data ---
     struct Ilk {
         address clip;  // Liquidator
+        uint256 step;  // Liquidation Ratio                                            [wad]
         uint256 chop;  // Liquidation Penalty                                          [wad]
         uint256 hole;  // Max DAI needed to cover debt+fees of active auctions per ilk [rad]
         uint256 dirt;  // Amt DAI needed to cover debt+fees of active auctions per ilk [rad]
@@ -134,6 +135,7 @@ contract Dog {
     }
     function file(bytes32 ilk, bytes32 what, uint256 data) external auth {
         if (what == "chop") ilks[ilk].chop = data;
+        else if (what == "step") ilks[ilk].step = data;
         else if (what == "hole") ilks[ilk].hole = data;
         else revert("Dog/file-unrecognized-param");
         emit FileIlkUint256(ilk, what, data);
@@ -160,7 +162,7 @@ contract Dog {
         {
             uint256 spot;
             (,rate, spot,, dust) = vat.ilks(ilk);
-            require(spot > 0 && mul(ink, spot) < mul(art, rate), "Dog/not-unsafe");
+            require(spot > 0 && mul(ink, spot) < mul(mul(art, milk.step) / WAD, rate), "Dog/not-unsafe");
 
             // Get the minimum value between:
             // 1) Remaining space in the general Hole

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -313,6 +313,7 @@ contract ClipperTest is DSTest {
         clip.rely(address(dog));
 
         dog.file(ilk, "clip", address(clip));
+        dog.file(ilk, "step", WAD);
         dog.file(ilk, "chop", 1.1 ether); // 10% chop
         dog.file(ilk, "hole", rad(1000 ether));
         dog.file("Hole", rad(1000 ether));
@@ -350,7 +351,7 @@ contract ClipperTest is DSTest {
 
     function test_get_chop() public {
         uint256 chop = dog.chop(ilk);
-        (, uint256 chop2,,) = dog.ilks(ilk);
+        (,, uint256 chop2,,) = dog.ilks(ilk);
         assertEq(chop, chop2);
     }
 
@@ -646,7 +647,7 @@ contract ClipperTest is DSTest {
 
     function test_Hole_hole() public {
         assertEq(dog.Dirt(), 0);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,,, uint256 dirt) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me, address(this));
@@ -654,7 +655,7 @@ contract ClipperTest is DSTest {
         (, uint256 tab,,,,) = clip.sales(1);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt) = dog.ilks(ilk);
+        (,,,, dirt) = dog.ilks(ilk);
         assertEq(dirt, tab);
 
         bytes32 ilk2 = "silver";
@@ -662,6 +663,7 @@ contract ClipperTest is DSTest {
         clip2.rely(address(dog));
 
         dog.file(ilk2, "clip", address(clip2));
+        dog.file(ilk2, "step", WAD);
         dog.file(ilk2, "chop", 1.1 ether);
         dog.file(ilk2, "hole", rad(1000 ether));
         dog.rely(address(clip2));
@@ -687,8 +689,8 @@ contract ClipperTest is DSTest {
         (, uint256 tab2,,,,) = clip2.sales(1);
 
         assertEq(dog.Dirt(), tab + tab2);
-        (,,, dirt) = dog.ilks(ilk);
-        (,,, uint256 dirt2) = dog.ilks(ilk2);
+        (,,,, dirt) = dog.ilks(ilk);
+        (,,,, uint256 dirt2) = dog.ilks(ilk2);
         assertEq(dirt, tab);
         assertEq(dirt2, tab2);
     }
@@ -700,7 +702,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether);
 
         assertEq(dog.Dirt(), 0);
-        (,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
+        (,,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me, address(this));
@@ -716,7 +718,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether - tab * WAD / rate / chop);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt) = dog.ilks(ilk);
+        (,,,, dirt) = dog.ilks(ilk);
         assertEq(dirt, tab);
     }
 
@@ -727,7 +729,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether);
 
         assertEq(dog.Dirt(), 0);
-        (,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
+        (,,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me, address(this));
@@ -743,7 +745,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether - tab * WAD / rate / chop);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt) = dog.ilks(ilk);
+        (,,,, dirt) = dog.ilks(ilk);
         assertEq(dirt, tab);
     }
 
@@ -1250,7 +1252,7 @@ contract ClipperTest is DSTest {
 
         // Assert that callback to clear dirt was successful.
         assertEq(dog.Dirt(), 0);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,,, uint256 dirt) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         // Assert transfer of gem.

--- a/src/test/dog.t.sol
+++ b/src/test/dog.t.sol
@@ -40,6 +40,7 @@ contract DogTest is DSTest {
         clip = new ClipperMock();
         dog = new Dog(address(vat));
         vat.rely(address(dog));
+        dog.file(ilk, "step", WAD);
         dog.file(ilk, "chop", 11 * WAD / 10);
         dog.file("vow", address(vow));
         dog.file(ilk, "clip", address(clip));
@@ -59,7 +60,7 @@ contract DogTest is DSTest {
     function isDusty() internal returns (bool dusty) {
         (, uint256 rate,,, uint256 dust) = vat.ilks(ilk);
         (, uint256 art) = vat.urns(ilk, usr);
-        (, uint256 chop,,) = dog.ilks(ilk);
+        (,, uint256 chop,,) = dog.ilks(ilk);
         uint256 due = art * rate;
         uint256 tab = due * chop / WAD;
         dusty = tab > 0 && tab < dust;

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -184,6 +184,7 @@ contract EndTest is DSTest {
         clip.rely(address(dog));
         dog.rely(address(clip));
         dog.file(name, "clip", address(clip));
+        dog.file(name, "step", WAD);
         dog.file(name, "chop", 1.1 ether);
         dog.file(name, "hole", rad(25000 ether));
         dog.file("Hole", rad((25000 ether)));


### PR DESCRIPTION
Not super sold on the name `step`, but basically this small addition will enable to set the liquidation ratio to be less than the vat collateralization ratio. If this has to be pushed after the initial LIQ-2.0 launch so be it, but I figured it was worth discussing to maybe sneak it in while we are still finalizing deployment.

The `step` multiplication is performed to the `art` instead of the `art * rate` so as to not to hit the overflow limit.