### PR TITLE
Don't set unstable default values in stairstep constructor

### DIFF
--- a/src/abaci.sol
+++ b/src/abaci.sol
@@ -160,7 +160,7 @@ contract StairstepExponentialDecrease is Abacus {
     // dur: seconds since the auction has started
     // step: seconds between a price drop
     // cut: cut is the percentage to decrease. In the code, it is represented as 1 - (% value / 100)
-    // So, a 1 % decrease, cut would be 1 - 0.01
+    // So, a 1 % decrease, cut would be (1 - 0.01) * RAY
     //
     // returns: top * (cut ^ (dur / step))
     //

--- a/src/abaci.sol
+++ b/src/abaci.sol
@@ -109,7 +109,7 @@ contract StairstepExponentialDecrease is Abacus {
 
     // --- Init ---
     // @notice: `cut` and `step` values must be correctly set for
-    //     this function to return a valid price
+    //     this contract to return a valid price
     constructor() public {
         wards[msg.sender] = 1;
         emit Rely(msg.sender);

--- a/src/abaci.sol
+++ b/src/abaci.sol
@@ -165,6 +165,8 @@ contract StairstepExponentialDecrease is Abacus {
     // returns: top * (cut ^ (dur / step))
     //
     function price(uint256 top, uint256 dur) override external view returns (uint256) {
-        return rmul(top, rpow(cut, dur / step, RAY));
+        uint256  _cut = cut;
+        require(_cut > 0, "StairstepExponentialDecrease/invalid-cut");
+        return rmul(top, rpow(_cut, dur / step, RAY));
     }
 }

--- a/src/abaci.sol
+++ b/src/abaci.sol
@@ -108,6 +108,8 @@ contract StairstepExponentialDecrease is Abacus {
     event FileUint256(bytes32 indexed what, uint256 data);
 
     // --- Init ---
+    // @notice: `cut` and `step` values must be correctly set for
+    //     this function to return a valid price
     constructor() public {
         wards[msg.sender] = 1;
         emit Rely(msg.sender);
@@ -165,8 +167,6 @@ contract StairstepExponentialDecrease is Abacus {
     // returns: top * (cut ^ (dur / step))
     //
     function price(uint256 top, uint256 dur) override external view returns (uint256) {
-        uint256  _cut = cut;
-        require(_cut > 0, "StairstepExponentialDecrease/invalid-cut");
-        return rmul(top, rpow(_cut, dur / step, RAY));
+        return rmul(top, rpow(cut, dur / step, RAY));
     }
 }

--- a/src/abaci.sol
+++ b/src/abaci.sol
@@ -110,8 +110,6 @@ contract StairstepExponentialDecrease is Abacus {
     // --- Init ---
     constructor() public {
         wards[msg.sender] = 1;
-        cut  = 0;
-        step = 1;
         emit Rely(msg.sender);
     }
 


### PR DESCRIPTION
Addresses QSP-12.2 - The values set in the constructor are not valid parameters. Simplest solution here is to just remove them.