### PR TITLE
Modernizing ERC20 DAI

### DIFF
--- a/src/dai.sol
+++ b/src/dai.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Copyright (C) 2017, 2018, 2019 dbrock, rain, mrchico
+// Copyright (C) 2021 MakerDAO
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -17,13 +18,18 @@
 
 pragma solidity >=0.5.12;
 
-import "./lib.sol";
-
-contract Dai is LibNote {
+contract Dai {
+        
     // --- Auth ---
-    mapping (address => uint) public wards;
-    function rely(address guy) external note auth { wards[guy] = 1; }
-    function deny(address guy) external note auth { wards[guy] = 0; }
+    mapping (address => uint256) public wards;
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
     modifier auth {
         require(wards[msg.sender] == 1, "Dai/not-authorized");
         _;
@@ -32,32 +38,35 @@ contract Dai is LibNote {
     // --- ERC20 Data ---
     string  public constant name     = "Dai Stablecoin";
     string  public constant symbol   = "DAI";
-    string  public constant version  = "1";
+    string  public constant version  = "2";
     uint8   public constant decimals = 18;
     uint256 public totalSupply;
 
-    mapping (address => uint)                      public balanceOf;
-    mapping (address => mapping (address => uint)) public allowance;
-    mapping (address => uint)                      public nonces;
+    mapping (address => uint256)                      public balanceOf;
+    mapping (address => mapping (address => uint256)) public allowance;
+    mapping (address => uint256)                      public nonces;
 
-    event Approval(address indexed src, address indexed guy, uint wad);
-    event Transfer(address indexed src, address indexed dst, uint wad);
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
 
     // --- Math ---
-    function add(uint x, uint y) internal pure returns (uint z) {
+    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x + y) >= x);
     }
-    function sub(uint x, uint y) internal pure returns (uint z) {
+    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x - y) <= x);
     }
 
     // --- EIP712 niceties ---
     bytes32 public DOMAIN_SEPARATOR;
-    // bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
-    bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
+    bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
     constructor(uint256 chainId_) public {
         wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+
         DOMAIN_SEPARATOR = keccak256(abi.encode(
             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
             keccak256(bytes(name)),
@@ -65,31 +74,33 @@ contract Dai is LibNote {
             chainId_,
             address(this)
         ));
+
+        // Set addresses which disallow transfer
+        balanceOf[address(this)] = uint256(-1);
+        balanceOf[address(0)] = uint256(-1);
     }
 
     // --- Token ---
-    function transfer(address dst, uint wad) external returns (bool) {
+    function transfer(address dst, uint256 wad) external returns (bool) {
         return transferFrom(msg.sender, dst, wad);
     }
-    function transferFrom(address src, address dst, uint wad)
-        public returns (bool)
-    {
+    function transferFrom(address src, address dst, uint256 wad) public returns (bool) {
         require(balanceOf[src] >= wad, "Dai/insufficient-balance");
         if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
-            require(allowance[src][msg.sender] >= wad, "Dai/insufficient-allowance");
-            allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
+                require(allowance[src][msg.sender] >= wad, "Dai/insufficient-allowance");
+                allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
         }
         balanceOf[src] = sub(balanceOf[src], wad);
         balanceOf[dst] = add(balanceOf[dst], wad);
         emit Transfer(src, dst, wad);
         return true;
     }
-    function mint(address usr, uint wad) external auth {
+    function mint(address usr, uint256 wad) external auth {
         balanceOf[usr] = add(balanceOf[usr], wad);
         totalSupply    = add(totalSupply, wad);
         emit Transfer(address(0), usr, wad);
     }
-    function burn(address usr, uint wad) external {
+    function burn(address usr, uint256 wad) external {
         require(balanceOf[usr] >= wad, "Dai/insufficient-balance");
         if (usr != msg.sender && allowance[usr][msg.sender] != uint(-1)) {
             require(allowance[usr][msg.sender] >= wad, "Dai/insufficient-allowance");
@@ -99,45 +110,33 @@ contract Dai is LibNote {
         totalSupply    = sub(totalSupply, wad);
         emit Transfer(usr, address(0), wad);
     }
-    function approve(address usr, uint wad) external returns (bool) {
+    function approve(address usr, uint256 wad) external returns (bool) {
         allowance[msg.sender][usr] = wad;
         emit Approval(msg.sender, usr, wad);
         return true;
     }
 
-    // --- Alias ---
-    function push(address usr, uint wad) external {
-        transferFrom(msg.sender, usr, wad);
-    }
-    function pull(address usr, uint wad) external {
-        transferFrom(usr, msg.sender, wad);
-    }
-    function move(address src, address dst, uint wad) external {
-        transferFrom(src, dst, wad);
-    }
-
     // --- Approve by signature ---
-    function permit(address holder, address spender, uint256 nonce, uint256 expiry,
-                    bool allowed, uint8 v, bytes32 r, bytes32 s) external
-    {
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external {
+        require(block.timestamp <= deadline, "Dai/permit-expired");
+
         bytes32 digest =
             keccak256(abi.encodePacked(
-                "\x19\x01",
-                DOMAIN_SEPARATOR,
-                keccak256(abi.encode(PERMIT_TYPEHASH,
-                                     holder,
-                                     spender,
-                                     nonce,
-                                     expiry,
-                                     allowed))
-        ));
+                    "\x19\x01",
+                    DOMAIN_SEPARATOR,
+                    keccak256(abi.encode(
+                        PERMIT_TYPEHASH,
+                        owner,
+                        spender,
+                        value,
+                        nonces[owner]++,
+                        deadline
+                    ))
+            ));
 
-        require(holder != address(0), "Dai/invalid-address-0");
-        require(holder == ecrecover(digest, v, r, s), "Dai/invalid-permit");
-        require(expiry == 0 || now <= expiry, "Dai/permit-expired");
-        require(nonce == nonces[holder]++, "Dai/invalid-nonce");
-        uint wad = allowed ? uint(-1) : 0;
-        allowance[holder][spender] = wad;
-        emit Approval(holder, spender, wad);
+        require(owner == ecrecover(digest, v, r, s), "Dai/invalid-permit");
+
+        allowance[owner][spender] = value;
+        emit Approval(owner, spender, value);
     }
 }

--- a/src/dai.sol
+++ b/src/dai.sol
@@ -133,7 +133,7 @@ contract Dai {
                     ))
             ));
 
-        require(owner == ecrecover(digest, v, r, s), "Dai/invalid-permit");
+        require(owner != address(0) && owner == ecrecover(digest, v, r, s), "Dai/invalid-permit");
 
         allowance[owner][spender] = value;
         emit Approval(owner, spender, value);

--- a/src/dai.sol
+++ b/src/dai.sol
@@ -77,7 +77,6 @@ contract Dai {
 
         // Set addresses which disallow transfer
         balanceOf[address(this)] = uint256(-1);
-        balanceOf[address(0)] = uint256(-1);
     }
 
     // --- Token ---

--- a/src/test/dai.t.sol
+++ b/src/test/dai.t.sol
@@ -102,14 +102,11 @@ contract DaiTest is DSTest {
     uint fee = 1;
     uint nonce = 0;
     uint deadline = 0;
-    address cal = 0x29C76e6aD8f28BB1004902578Fb108c507Be341b;
+    address cal = 0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1;
     address del = 0xdd2d5D3f7f1b35b7A0601D6A00DbB7D44Af58479;
-    bytes32 r = 0x46323dda87c592902a10f931e64a8160ae899d141f46b07a73e676b0e5daa1c4;
-    bytes32 s = 0x6339a2fc9fdf1c0737fb35eb0928f0558170e3900da9b483ed1904bd9fdb2f87;
+    bytes32 r = 0xf4deb87c6a5676297bed14226df809c5b41cc632151079051f5db1af5698cc18;
+    bytes32 s = 0x377c682cca592b251e216ece7371c64b1cd06f8edd52f21bae61f4b19bebc6f3;
     uint8 v = 28;
-    bytes32 _r = 0x8c37dc98d15d1f9907c731184d4aaad7896d5d9424c8a5c002bc569b3bf50ba6;
-    bytes32 _s = 0x0a561c49460341843d248c63923be1d7c67bc2b5753bd07835be47828e4d0c2e;
-    uint8 _v = 27;
 
 
     function setUp() public {
@@ -283,41 +280,23 @@ contract DaiTest is DSTest {
     }
 
     function testTypehash() public {
-        assertEq(token.PERMIT_TYPEHASH(), 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb);
+        assertEq(token.PERMIT_TYPEHASH(), 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9);
     }
 
     function testDomain_Separator() public {
-        assertEq(token.DOMAIN_SEPARATOR(), 0x92a148ae95a9faf19ab88b195b0da85dd00a6764ac8a66d5e64fb3add1579cac);
-    }
-
-    function testPermit() public {
-        assertEq(token.nonces(cal), 0);
-        assertEq(token.allowance(cal, del), 0);
-        token.permit(cal, del, 0, 0, true, v, r, s);
-        assertEq(token.allowance(cal, del),uint(-1));
-        assertEq(token.nonces(cal),1);
-    }
-
-    function testFailPermitAddress0() public {
-        v = 0;
-        token.permit(address(0), del, 0, 0, true, v, r, s);
+        assertEq(token.DOMAIN_SEPARATOR(), 0xc783c8c902fe442ca30c87a62e8e823b3b761301f0bf863830e1ba5608b74f75);
     }
 
     function testPermitWithExpiry() public {
         assertEq(now, 604411200);
-        token.permit(cal, del, 0, 604411200 + 1 hours, true, _v, _r, _s);
-        assertEq(token.allowance(cal, del),uint(-1));
-        assertEq(token.nonces(cal),1);
+        token.permit(cal, del, 100, 604411200 + 1 hours, v, r, s);
+        assertEq(token.allowance(cal, del), 100);
+        assertEq(token.nonces(cal), 1);
     }
 
     function testFailPermitWithExpiry() public {
         hevm.warp(now + 2 hours);
         assertEq(now, 604411200 + 2 hours);
-        token.permit(cal, del, 0, 1, true, _v, _r, _s);
-    }
-
-    function testFailReplay() public {
-        token.permit(cal, del, 0, 0, true, v, r, s);
-        token.permit(cal, del, 0, 0, true, v, r, s);
+        token.permit(cal, del, 100, 1, v, r, s);
     }
 }


### PR DESCRIPTION
Bring ERC20 DAI into 2021. The following changes are proposed:

* uint -> uint256
* Use events instead of LibNote
* Newer `permit` supports any value instead of on/off
* Remove non-erc20 aliases
* Prevent transferring to the DAI contract and address 0

TODO:

* Flash mint support?
* `permit` test hashes need to be re-calculated.