### PR TITLE
validation for chop

### DIFF
--- a/src/dog.sol
+++ b/src/dog.sol
@@ -133,7 +133,7 @@ contract Dog {
         emit File(what, data);
     }
     function file(bytes32 ilk, bytes32 what, uint256 data) external auth {
-        if (what == "chop") ilks[ilk].chop = data;
+        if (what == "chop") { require(data >= WAD); ilks[ilk].chop = data; }
         else if (what == "hole") ilks[ilk].hole = data;
         else revert("Dog/file-unrecognized-param");
         emit File(ilk, what, data);

--- a/src/test/dog.t.sol
+++ b/src/test/dog.t.sol
@@ -47,6 +47,19 @@ contract DogTest is DSTest {
         dog.file(ilk, "hole", 10 * THOUSAND * RAD);
     }
 
+    function test_file_chop() public {
+        dog.file(ilk, "chop", WAD);
+        dog.file(ilk, "chop", WAD * 113 / 100);
+    }
+
+    function testFail_file_chop_lt_WAD() public {
+        dog.file(ilk, "chop", WAD - 1);
+    }
+
+    function testFail_file_chop_eq_zero() public {
+        dog.file(ilk, "chop", 0);
+    }
+
     function setUrn(uint256 ink, uint256 art) internal {
         vat.slip(ilk, usr, int256(ink));
         (, uint256 rate,,,) = vat.ilks(ilk);


### PR DESCRIPTION
Both Quantstamp and ToB have pointed to potential issues if `chop` is zero or just very small (e.g. liquidations being disabled). There's also a very strong correctness argument that it should never be less than `WAD` due to auction grinding. IMO in this case a little input validation is justified.