### PR TITLE
add continuous exponential decrease

### DIFF
--- a/src/abaci.sol
+++ b/src/abaci.sol
@@ -161,10 +161,12 @@ contract StairstepExponentialDecrease is Abacus {
     // top: initial price
     // dur: seconds since the auction has started
     // step: seconds between a price drop
-    // cut: cut is the percentage to decrease. In the code, it is represented as 1 - (% value / 100)
-    // So, a 1 % decrease, cut would be (1 - 0.01) * RAY
+    // cut: cut encodes the percentage to decrease per step.
+    //   For efficiency, the values is set as (1 - (% value / 100)) * RAY
+    //   So, for a 1% decrease per step, cut would be (1 - 0.01) * RAY
     //
-    // returns: top * (cut ^ (dur / step))
+    // returns: top * (cut ^ dur)
+    //
     //
     function price(uint256 top, uint256 dur) override external view returns (uint256) {
         return rmul(top, rpow(cut, dur / step, RAY));
@@ -247,8 +249,8 @@ contract ExponentialDecrease is Abacus {
     // top: initial price
     // dur: seconds since the auction has started
     // cut: cut encodes the percentage to decrease per second.
-    // For efficiency, the values is set as (1 - (% value / 100)) * RAY
-    // So, for a 1% decrease per second, cut would be (1 - 0.01) * RAY
+    //   For efficiency, the values is set as (1 - (% value / 100)) * RAY
+    //   So, for a 1% decrease per second, cut would be (1 - 0.01) * RAY
     //
     // returns: top * (cut ^ dur)
     //

--- a/src/abaci.sol
+++ b/src/abaci.sol
@@ -170,3 +170,89 @@ contract StairstepExponentialDecrease is Abacus {
         return rmul(top, rpow(cut, dur / step, RAY));
     }
 }
+
+// While an equivalent function can be obtained by setting step = 1 in StairstepExponentialDecrease,
+// this continous (i.e. per-second) exponential decrease has be implemented as it is more gas-efficient
+// than using the stairstep version with step = 1 (primarily due to 1 fewer SLOAD per price calculation).
+contract ExponentialDecrease is Abacus {
+
+    // --- Auth ---
+    mapping (address => uint256) public wards;
+    function rely(address usr) external auth { wards[usr] = 1; emit Rely(usr); }
+    function deny(address usr) external auth { wards[usr] = 0; emit Deny(usr); }
+    modifier auth {
+        require(wards[msg.sender] == 1, "ExponentialDecrease/not-authorized");
+        _;
+    }
+
+    // --- Data ---
+    uint256 public cut;  // Per-second multiplicative factor [ray]
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+
+    event FileUint256(bytes32 indexed what, uint256 data);
+
+    // --- Init ---
+    // @notice: `cut` value must be correctly set for
+    //     this contract to return a valid price
+    constructor() public {
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+    }
+
+    // --- Administration ---
+    function file(bytes32 what, uint256 data) external auth {
+        if      (what ==  "cut") require((cut = data) <= RAY, "ExponentialDecrease/cut-gt-RAY");
+        else revert("ExponentialDecrease/file-unrecognized-param");
+        emit FileUint256(what, data);
+    }
+
+    // --- Math ---
+    uint256 constant RAY = 10 ** 27;
+    function rmul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = x * y;
+        require(y == 0 || z / y == x);
+        z = z / RAY;
+    }
+    // optimized version from dss PR #78
+    function rpow(uint256 x, uint256 n, uint256 b) internal pure returns (uint256 z) {
+        assembly {
+            switch n case 0 { z := b }
+            default {
+                switch x case 0 { z := 0 }
+                default {
+                    switch mod(n, 2) case 0 { z := b } default { z := x }
+                    let half := div(b, 2)  // for rounding.
+                    for { n := div(n, 2) } n { n := div(n,2) } {
+                        let xx := mul(x, x)
+                        if shr(128, x) { revert(0,0) }
+                        let xxRound := add(xx, half)
+                        if lt(xxRound, xx) { revert(0,0) }
+                        x := div(xxRound, b)
+                        if mod(n,2) {
+                            let zx := mul(z, x)
+                            if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
+                            let zxRound := add(zx, half)
+                            if lt(zxRound, zx) { revert(0,0) }
+                            z := div(zxRound, b)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // top: initial price
+    // dur: seconds since the auction has started
+    // cut: cut encodes the percentage to decrease per second.
+    // For efficiency, the values is set as (1 - (% value / 100)) * RAY
+    // So, for a 1% decrease per second, cut would be (1 - 0.01) * RAY
+    //
+    // returns: top * (cut ^ dur)
+    //
+    function price(uint256 top, uint256 dur) override external view returns (uint256) {
+        return rmul(top, rpow(cut, dur, RAY));
+    }
+}

--- a/src/test/abaci.t.sol
+++ b/src/test/abaci.t.sol
@@ -153,7 +153,7 @@ contract ClipperTest is DSTest {
         uint256 top = 4000 * RAY;
         uint256 expectedPrice = top;
         uint256 tolerance = RAY / 1000;  // 0.001, i.e 0.1%
-        for (uint256 i = 0; i < 1; i++) {  // will cover initial value + four half-lives
+        for (uint256 i = 0; i < 5; i++) {  // will cover initial value + four half-lives
             assertEqWithinTolerance(calc.price(top, i*tHalf), expectedPrice, tolerance);
             // each loop iteration advances one half-life, so expectedPrice decreases by a factor of 2
             expectedPrice /= 2;

--- a/src/test/abaci.t.sol
+++ b/src/test/abaci.t.sol
@@ -27,6 +27,19 @@ contract ClipperTest is DSTest {
         hevm.warp(startTime);
     }
 
+    function assertEqWithinTolerance(
+        uint256 x,
+        uint256 y,
+        uint256 tolerance) internal {
+            uint256 diff;
+            if (x >= y) {
+                diff = x - y;
+            } else {
+                diff = y - x;
+            }
+            assertTrue(diff <= tolerance);
+    }
+
     function checkExpDecrease(
         StairstepExponentialDecrease calc,
         uint256 cut,
@@ -41,7 +54,6 @@ contract ClipperTest is DSTest {
     {
         uint256 price;
         uint256 lastPrice;
-        uint256 diff;
         uint256 testPrice;
 
         hevm.warp(startTime);
@@ -57,13 +69,7 @@ contract ClipperTest is DSTest {
             // Stairstep calculation
             if (i % step == 0) { testPrice = lastPrice * percentDecrease / RAY; }
             else               { testPrice = lastPrice; }
-            // Tolerance calculation
-            if (testPrice >= price) { diff = testPrice - price; }
-            else                    { diff = price - testPrice; }
-            // Precision is lost as price goes higher (can only get 10^27 max precision).
-            // E.g., top = 50m => Expected: 16338200015683006288456874400625678
-            //                    Actual:   16338200015683006288456874350000000
-            assertTrue(diff <= tolerance);
+            assertEqWithinTolerance(testPrice, price, tolerance);
         }
     }
 
@@ -136,6 +142,22 @@ contract ClipperTest is DSTest {
         percentDecrease = RAY - 1.1234567890E27 / 100;
         step = 5 minutes;
         checkExpDecrease(calc, percentDecrease, step, top, tic, percentDecrease, testTime, tolerance);
+    }
+
+    function test_continuous_exp_decrease() public {
+        ExponentialDecrease calc = new ExponentialDecrease();
+        uint256 tHalf = 900;
+        uint256 cut = 0.999230132966E27;  // ~15 half life, cut ~= e^(ln(1/2)/900)
+        calc.file("cut", cut);
+
+        uint256 top = 4000 * RAY;
+        uint256 expectedPrice = top;
+        uint256 tolerance = RAY / 1000;  // 0.001, i.e 0.1%
+        for (uint256 i = 0; i < 1; i++) {  // will cover initial value + four half-lives
+            assertEqWithinTolerance(calc.price(top, i*tHalf), expectedPrice, tolerance);
+            // each loop iteration advances one half-life, so expectedPrice decreases by a factor of 2
+            expectedPrice /= 2;
+        }
     }
 
     function test_linear_decrease() public {


### PR DESCRIPTION
There are fair arguments that maybe the stairstep functionality is not really beneficial; while `step` could always be set to 1 in that case, it's more gas-efficient to have a separate function that won't do the pointless `SLOAD` if a continuous exponential proves preferable.