### PR TITLE
Return lot size with getStatus

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -442,7 +442,7 @@ contract Clipper {
     }
 
     // Externally returns boolean for if an auction needs a redo and also the current price
-    function getStatus(uint256 id) external view returns (bool needsRedo, uint256 price, uint256 lot) {
+    function getStatus(uint256 id) external view returns (bool needsRedo, uint256 price, uint256 lot, uint256 tab) {
         // Read auction data
         address usr = sales[id].usr;
         uint96  tic = sales[id].tic;
@@ -452,6 +452,7 @@ contract Clipper {
 
         needsRedo = usr != address(0) && done;
         lot = sales[id].lot;
+        tab = sales[id].tab;
     }
 
     // Internally returns boolean for if an auction needs a redo

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -440,7 +440,7 @@ contract Clipper {
     }
 
     // Externally returns boolean for if an auction needs a redo and also the current price
-    function getStatus(uint256 id) external view returns (bool needsRedo, uint256 price) {
+    function getStatus(uint256 id) external view returns (bool needsRedo, uint256 price, uint256 lot) {
         // Read auction data
         address usr = sales[id].usr;
         uint96  tic = sales[id].tic;
@@ -449,6 +449,7 @@ contract Clipper {
         (done, price) = status(tic, sales[id].top);
 
         needsRedo = usr != address(0) && done;
+        lot = sales[id].lot;
     }
 
     // Internally returns boolean for if an auction needs a redo

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -516,7 +516,7 @@ contract ClipperTest is DSTest {
         pip.poke(bytes32(0));
 
         hevm.warp(startTime + 1801 seconds);
-        (bool needsRedo,,) = clip.getStatus(1);
+        (bool needsRedo,,,) = clip.getStatus(1);
         assertTrue(needsRedo);
         clip.redo(1, address(this));
     }
@@ -973,8 +973,9 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
 
-        (, uint256 price,uint256 _lot) = clip.getStatus(1);
+        (, uint256 price,uint256 _lot, uint256 _tab) = clip.getStatus(1);
         assertEq(_lot, lot);
+        assertEq(_tab, tab);
         assertEq(price, ray(5 ether));
 
         // Bid so owe (= (22 - 1wei) * 5 = 110 RAD - 1) < tab (= 110 RAD)
@@ -999,7 +1000,7 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
 
-        (, uint256 price,) = clip.getStatus(1);
+        (, uint256 price,,) = clip.getStatus(1);
         assertEq(price, 2735783211953807380973706855); // 2.73 RAY
 
         // Bid so owe (= (22 - 1wei) * 5 = 110 RAD - 1) < tab (= 110 RAD)
@@ -1021,7 +1022,7 @@ contract ClipperTest is DSTest {
     }
 
     function test_take_bid_fails_no_partial_allowed() public takeSetup {
-        (, uint256 price,) = clip.getStatus(1);
+        (, uint256 price,,) = clip.getStatus(1);
         assertEq(price, ray(5 ether));
 
         clip.take({
@@ -1085,7 +1086,7 @@ contract ClipperTest is DSTest {
 
         hevm.warp(now + 30);
 
-        (, uint256 _price, uint256 _lot) = clip.getStatus(1);
+        (, uint256 _price, uint256 _lot, uint256 _tab) = clip.getStatus(1);
         Guy(bob).take({
             id:  1,
             amt: _lot,     // Buy the rest of the lot
@@ -1142,11 +1143,11 @@ contract ClipperTest is DSTest {
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
 
         hevm.warp(startTime + 3600 seconds);
-        (bool needsRedo,,) = clip.getStatus(1);
+        (bool needsRedo,,,) = clip.getStatus(1);
         assertTrue(!needsRedo);
         assertTrue(!try_redo(1, address(this)));
         hevm.warp(startTime + 3601 seconds);
-        (needsRedo,,) = clip.getStatus(1);
+        (needsRedo,,,) = clip.getStatus(1);
         assertTrue(needsRedo);
         assertTrue(try_redo(1, address(this)));
 
@@ -1165,11 +1166,11 @@ contract ClipperTest is DSTest {
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
 
         hevm.warp(startTime + 1800 seconds);
-        (bool needsRedo,,) = clip.getStatus(1);
+        (bool needsRedo,,,) = clip.getStatus(1);
         assertTrue(!needsRedo);
         assertTrue(!try_redo(1, address(this)));
         hevm.warp(startTime + 1801 seconds);
-        (needsRedo,,) = clip.getStatus(1);
+        (needsRedo,,,) = clip.getStatus(1);
         assertTrue(needsRedo);
         assertTrue(try_redo(1, address(this)));
 
@@ -1335,7 +1336,7 @@ contract ClipperTest is DSTest {
 
         hevm.warp(now + 100); // Reducing the price
 
-        (, uint256 price,) = clip.getStatus(1);
+        (, uint256 price,,) = clip.getStatus(1);
         assertEq(price, 1830161706366147524653080130); // 1.83 RAY
 
         clip.take({


### PR DESCRIPTION
Keeper accessibility improvement. Returns the available `lot` with `getStatus()` so a keeper only needs to make one call to get the price and lot size before performing a `take`