### PR TITLE
Validate ilk when filing clip in Dog

### DIFF
--- a/src/dog.sol
+++ b/src/dog.sol
@@ -20,6 +20,7 @@
 pragma solidity >=0.6.12;
 
 interface ClipperLike {
+    function ilk() external view returns (bytes32);
     function kick(
         uint256 tab,
         uint256 lot,
@@ -133,14 +134,18 @@ contract Dog {
         emit File(what, data);
     }
     function file(bytes32 ilk, bytes32 what, uint256 data) external auth {
-        if (what == "chop") { require(data >= WAD); ilks[ilk].chop = data; }
-        else if (what == "hole") ilks[ilk].hole = data;
+        if (what == "chop") {
+            require(data >= WAD, "Dog/file-chop-lt-WAD");
+            ilks[ilk].chop = data;
+        } else if (what == "hole") ilks[ilk].hole = data;
         else revert("Dog/file-unrecognized-param");
         emit File(ilk, what, data);
     }
     function file(bytes32 ilk, bytes32 what, address clip) external auth {
-        if (what == "clip") ilks[ilk].clip = clip;
-        else revert("Dog/file-unrecognized-param");
+        if (what == "clip") {
+            require(ilk == ClipperLike(clip).ilk(), "Dog/file-ilk-neq-clip.ilk");
+            ilks[ilk].clip = clip;
+        } else revert("Dog/file-unrecognized-param");
         emit File(ilk, what, clip);
     }
 

--- a/src/test/dog.t.sol
+++ b/src/test/dog.t.sol
@@ -11,6 +11,10 @@ contract VowMock {
 }
 
 contract ClipperMock {
+    bytes32 public ilk;
+    function setIlk(bytes32 wat) external {
+        ilk = wat;
+    }
     function kick(uint256, uint256, address, address)
         external pure returns (uint256 id) {
         id = 42;
@@ -37,6 +41,7 @@ contract DogTest is DSTest {
         vat.file(ilk, "dust", 100 * RAD);
         vow = new VowMock();
         clip = new ClipperMock();
+        clip.setIlk(ilk);
         dog = new Dog(address(vat));
         vat.rely(address(dog));
         dog.file(ilk, "chop", 11 * WAD / 10);
@@ -57,6 +62,10 @@ contract DogTest is DSTest {
 
     function testFail_file_chop_eq_zero() public {
         dog.file(ilk, "chop", 0);
+    }
+
+    function testFail_file_clip_wrong_ilk() public {
+        dog.file("mismatched_ilk", "clip", address(clip));
     }
 
     function setUrn(uint256 ink, uint256 art) internal {


### PR DESCRIPTION
Address a ToB finding. Collateral can become permanently stuck in a Clipper if it's for a different `ilk` than the immutable value the Clipper holds.