### PR TITLE
basic rate-limited hole

### DIFF
--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -415,7 +415,7 @@ contract ClipperTest is DSTest {
 
     function test_get_chop() public {
         uint256 chop = dog.chop(ilk);
-        (, uint256 chop2,,) = dog.ilks(ilk);
+        (, uint256 chop2,,,,,,) = dog.ilks(ilk);
         assertEq(chop, chop2);
     }
 
@@ -729,7 +729,7 @@ contract ClipperTest is DSTest {
 
     function test_Hole_hole() public {
         assertEq(dog.Dirt(), 0);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt,,,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me, address(this));
@@ -737,7 +737,7 @@ contract ClipperTest is DSTest {
         (, uint256 tab,,,,) = clip.sales(1);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt) = dog.ilks(ilk);
+        (,,, dirt,,,,) = dog.ilks(ilk);
         assertEq(dirt, tab);
 
         bytes32 ilk2 = "silver";
@@ -770,8 +770,8 @@ contract ClipperTest is DSTest {
         (, uint256 tab2,,,,) = clip2.sales(1);
 
         assertEq(dog.Dirt(), tab + tab2);
-        (,,, dirt) = dog.ilks(ilk);
-        (,,, uint256 dirt2) = dog.ilks(ilk2);
+        (,,, dirt,,,,) = dog.ilks(ilk);
+        (,,, uint256 dirt2,,,,) = dog.ilks(ilk2);
         assertEq(dirt, tab);
         assertEq(dirt2, tab2);
     }
@@ -783,7 +783,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether);
 
         assertEq(dog.Dirt(), 0);
-        (,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
+        (,uint256 chop,, uint256 dirt,,,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me, address(this));
@@ -799,7 +799,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether - tab * WAD / rate / chop);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt) = dog.ilks(ilk);
+        (,,, dirt,,,,) = dog.ilks(ilk);
         assertEq(dirt, tab);
     }
 
@@ -810,7 +810,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether);
 
         assertEq(dog.Dirt(), 0);
-        (,uint256 chop,, uint256 dirt) = dog.ilks(ilk);
+        (,uint256 chop,, uint256 dirt,,,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         dog.bark(ilk, me, address(this));
@@ -826,7 +826,7 @@ contract ClipperTest is DSTest {
         assertEq(_art(ilk, me), 100 ether - tab * WAD / rate / chop);
 
         assertEq(dog.Dirt(), tab);
-        (,,, dirt) = dog.ilks(ilk);
+        (,,, dirt,,,,) = dog.ilks(ilk);
         assertEq(dirt, tab);
     }
 
@@ -867,7 +867,7 @@ contract ClipperTest is DSTest {
         assertEq(top, 0);
 
         assertEq(dog.Dirt(), 0);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt,,,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
     }
 
@@ -895,7 +895,7 @@ contract ClipperTest is DSTest {
         assertEq(top, 0);
 
         assertEq(dog.Dirt(), 0);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt,,,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
     }
 
@@ -923,7 +923,7 @@ contract ClipperTest is DSTest {
         assertEq(top, ray(5 ether));
 
         assertEq(dog.Dirt(), tab);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt,,,,) = dog.ilks(ilk);
         assertEq(dirt, tab);
     }
 
@@ -953,7 +953,7 @@ contract ClipperTest is DSTest {
 
         // All dirt should be cleared, since the auction has ended, even though < 100% of tab was collected
         assertEq(dog.Dirt(), 0);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt,,,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
     }
 
@@ -1391,7 +1391,7 @@ contract ClipperTest is DSTest {
 
         // Assert that callback to clear dirt was successful.
         assertEq(dog.Dirt(), 0);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt,,,,) = dog.ilks(ilk);
         assertEq(dirt, 0);
 
         // Assert transfer of gem.

--- a/src/test/dog.t.sol
+++ b/src/test/dog.t.sol
@@ -112,7 +112,7 @@ contract DogTest is DSTest {
         vat.file(ilk, "dust", dust * RAD);
         uint256 hole = 5 * THOUSAND;
         dog.file(ilk, "hole", hole * RAD);
-        (, uint256 chop,,) = dog.ilks(ilk);
+        (, uint256 chop,,,,,,) = dog.ilks(ilk);
         uint256 artStart = hole * WAD * WAD / chop + dust * WAD - 1;
         setUrn(WAD, artStart);
         dog.bark(ilk, usr, address(this));
@@ -122,7 +122,7 @@ contract DogTest is DSTest {
         // The full vault has been liquidated so as not to leave a dusty remnant,
         // at the expense of slightly exceeding hole.
         assertEq(art, 0);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt,,,,) = dog.ilks(ilk);
         assertTrue(dirt > hole * RAD);
         assertEq(dirt, artStart * RAY * chop / WAD);
     }
@@ -132,7 +132,7 @@ contract DogTest is DSTest {
         vat.file(ilk, "dust", dust * RAD);
         uint256 hole = 5 * THOUSAND;
         dog.file(ilk, "hole", hole * RAD);
-        (, uint256 chop,,) = dog.ilks(ilk);
+        (, uint256 chop,,,,,,) = dog.ilks(ilk);
         setUrn(WAD, hole * WAD * WAD / chop + dust * WAD);
         dog.bark(ilk, usr, address(this));
         assertTrue(!isDusty());
@@ -140,7 +140,7 @@ contract DogTest is DSTest {
 
         // The vault remnant respects the dust limit, so we don't exceed hole to liquidate it.
         assertEq(art, dust * WAD);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt,,,,) = dog.ilks(ilk);
         assertTrue(dirt <= hole * RAD);
         assertEq(dirt, hole * RAD * WAD / RAY / chop * RAY * chop / WAD);
     }
@@ -150,7 +150,7 @@ contract DogTest is DSTest {
         vat.file(ilk, "dust", dust * RAD);
         uint256 Hole = 5 * THOUSAND;
         dog.file("Hole", Hole * RAD);
-        (, uint256 chop,,) = dog.ilks(ilk);
+        (, uint256 chop,,,,,,) = dog.ilks(ilk);
         uint256 artStart = Hole * WAD * WAD / chop + dust * WAD - 1;
         setUrn(WAD, artStart);
         dog.bark(ilk, usr, address(this));
@@ -169,7 +169,7 @@ contract DogTest is DSTest {
         vat.file(ilk, "dust", dust * RAD);
         uint256 Hole = 5 * THOUSAND;
         dog.file("Hole", Hole * RAD);
-        (, uint256 chop,,) = dog.ilks(ilk);
+        (, uint256 chop,,,,,,) = dog.ilks(ilk);
         setUrn(WAD, Hole * WAD * WAD / chop + dust * WAD);
         dog.bark(ilk, usr, address(this));
         assertTrue(!isDusty());
@@ -204,7 +204,7 @@ contract DogTest is DSTest {
         setUrn(WAD, (HOLE - ROOM) * RAD / rate * WAD / CHOP);
         dog.bark(ilk, usr, address(this));
         assertEq(HOLE * RAD - dog.Dirt(), ROOM * RAD);
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt,,,,) = dog.ilks(ilk);
         assertEq(HOLE * RAD - dirt, ROOM * RAD);
 
         // Create a small vault
@@ -222,7 +222,7 @@ contract DogTest is DSTest {
         // In fact, there is only room to create dusty auctions at this point.
         assertTrue(dog.Hole() - dog.Dirt() < DUST_2 * RAD * CHOP / WAD);
         uint256 hole;
-        (,, hole, dirt) = dog.ilks(ilk);
+        (,, hole, dirt,,,,) = dog.ilks(ilk);
         assertTrue(hole - dirt < DUST_2 * RAD * CHOP / WAD);
 
         // But...our Vault is small enough to fit in ROOM
@@ -248,12 +248,12 @@ contract DogTest is DSTest {
         (, uint256 rate,,,) = vat.ilks(ilk);
         assertEq(rate, (15 * RAY) / 10);
 
-        (, uint256 chop,,) = dog.ilks(ilk);
+        (, uint256 chop,,,,,,) = dog.ilks(ilk);
         setUrn(WAD, (hole - dust / 2) * RAD / rate * WAD / chop);
         dog.bark(ilk, usr, address(this));
 
         // Make sure any partial liquidation would be dusty (assuming non-dusty remnant)
-        (,,, uint256 dirt) = dog.ilks(ilk);
+        (,,, uint256 dirt,,,,) = dog.ilks(ilk);
         uint256 room = hole * RAD - dirt;
         uint256 dart = room * WAD / rate / chop;
         assertTrue(dart * rate < dust * RAD);
@@ -274,7 +274,7 @@ contract DogTest is DSTest {
         (, uint256 rate,,,) = vat.ilks(ilk);
         assertEq(rate, (15 * RAY) / 10);
 
-        (, uint256 chop,,) = dog.ilks(ilk);
+        (, uint256 chop,,,,,,) = dog.ilks(ilk);
         setUrn(WAD, (Hole - dust / 2) * RAD / rate * WAD / chop);
         dog.bark(ilk, usr, address(this));
 


### PR DESCRIPTION
DO NOT MERGE, FOR DISCUSSION PURPOSES ONLY

Here's a basic implementation of a `hole` that decays in a stepwise linear fashion.

It's stepwise because a continuous decrease would likely lead to too many small auctions in a case where we bumped into a `hole` limit.

Every `qntm` seconds, `dirt` can decrease by up to `clod`. This is triggered in `bark` (adds a lot of `SSTORE` ops, so incentives will matter). But the decrease is only allowed if enough DAI has been collected from auctions or is no longer associated with an auction. This is tracked as `trid` (`dirt` that has been "reversed"), so that if auctions are failing to recapitalize, we don't continue to liquidate. I think there may be an argument for removing this and simplifying to a purely time-based mechanism, but wanted to start from this formulation.