### PR TITLE
Consider liquidation price on take

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -201,6 +201,9 @@ contract Clipper {
     function rdiv(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = mul(x, RAY) / y;
     }
+    function max(uint x, uint y) internal pure returns (uint z) {
+        return x >= y ? x : y;
+    }
 
 
     // --- Auction ---
@@ -212,7 +215,7 @@ contract Clipper {
     function getPrice() internal returns (uint256 price) {
         (PipLike pip, ) = spotter.ilks(ilk);
         (bytes32 val, bool has) = pip.peek();
-        require(has, "Clipper/invalid-price");
+        require(has && uint256(val) > 0, "Clipper/invalid-price");
         price = rdiv(mul(uint256(val), BLN), spotter.par());
     }
 
@@ -248,7 +251,7 @@ contract Clipper {
         sales[id].tic = uint96(block.timestamp);
 
         uint256 top;
-        top = rmul(getPrice(), buf);
+        top = max(rmul(getPrice(), buf), tab / lot);
         require(top > 0, "Clipper/zero-top-price");
         sales[id].top = top;
 

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -223,7 +223,7 @@ contract Clipper {
     // note: trusts the caller to transfer collateral to the contract
     // The starting price `top` is obtained as follows:
     //
-    //     top = val * buf / par
+    //     top = max( val * buf / par , tab / lot )
     //
     // Where `val` is the collateral's unitary value in USD, `buf` is a
     // multiplicative factor to increase the starting price, and `par` is a


### PR DESCRIPTION
Takes the max of `getPrice()*buf` or `tab/lot` on `take` only.

This sets a price floor on initial `take`s to ward against an OSM attack.

This formula does not apply to `redo()` because the initial auction will take time. In a real oracle attack we'd resolve the oracle issue, but in a catastrophic market decline the `redo()` would rely entirely on the OSM price to set the price on the second try.