### PR TITLE
properly account for chop in dust checks in the Clipper

### DIFF
--- a/src/clip.sol
+++ b/src/clip.sol
@@ -365,11 +365,12 @@ contract Clipper {
                 slice = owe / price;        // slice' = owe' / price <= owe / price == slice <= lot
             } else if (owe < tab && slice < lot) {
                 // If slice == lot => auction completed => dust doesn't matter
-                if (tab - owe < chost) {     // safe as owe < tab
+                uint256 chost_ = chost;
+                if (tab - owe < chost_) {    // safe as owe < tab
                     // If tab <= chost, buyers have to take the entire lot.
-                    require(tab > chost, "Clipper/no-partial-purchase");
+                    require(tab > chost_, "Clipper/no-partial-purchase");
                     // Adjust amount to pay
-                    owe = tab - chost;       // owe' <= owe
+                    owe = tab - chost_;      // owe' <= owe
                     // Adjust slice
                     slice = owe / price;     // slice' = owe' / price < owe / price == slice < lot
                 }

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -451,10 +451,11 @@ contract Clipper {
         done  = (sub(block.timestamp, tic) > tail || rdiv(price, top) < cusp);
     }
 
-    // Public function to update the cached dust value.
+    // Public function to update the cached dust*chop value.
     function upchost() external {
-        (,,,, uint256 _dust) = VatLike(vat).ilks(ilk);
-        chost = wmul(_dust, dog.chop(ilk));
+        _ilk = ilk;  // cache
+        (,,,, uint256 _dust) = VatLike(vat).ilks(_ilk);
+        chost = wmul(_dust, dog.chop(_ilk));
     }
 
     // Cancel an auction during ES or via governance action.

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -309,7 +309,7 @@ contract Clipper {
     // Buy up to `amt` of collateral from the auction indexed by `id`.
     // 
     // Auctions will not collect more DAI than their assigned DAI target,`tab`;
-    // thus, if `amt` would cost more DAI than `tab` at the current price,, the
+    // thus, if `amt` would cost more DAI than `tab` at the current price, the
     // amount of collateral purchased will instead be just enough to collect `tab` DAI.
     //
     // To avoid partial purchases resulting in very small leftover auctions that will

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -442,7 +442,7 @@ contract Clipper {
     }
 
     // Externally returns boolean for if an auction needs a redo and also the current price
-    function getStatus(uint256 id) external view returns (bool needsRedo, uint256 price) {
+    function getStatus(uint256 id) external view returns (bool needsRedo, uint256 price, uint256 lot, uint256 tab) {
         // Read auction data
         address usr = sales[id].usr;
         uint96  tic = sales[id].tic;
@@ -451,6 +451,8 @@ contract Clipper {
         (done, price) = status(tic, sales[id].top);
 
         needsRedo = usr != address(0) && done;
+        lot = sales[id].lot;
+        tab = sales[id].tab;
     }
 
     // Internally returns boolean for if an auction needs a redo

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -453,7 +453,6 @@ contract Clipper {
 
     // Public function to update the cached dust*chop value.
     function upchost() external {
-        _ilk = ilk;  // cache
         (,,,, uint256 _dust) = VatLike(vat).ilks(_ilk);
         chost = wmul(_dust, dog.chop(_ilk));
     }

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -34,6 +34,7 @@ interface SpotterLike {
 }
 
 interface DogLike {
+    function chop(bytes32) external returns (uint256);
     function digs(bytes32, uint256) external;
 }
 
@@ -294,7 +295,7 @@ contract Clipper {
         uint256 coin;
         if (_tip > 0 || _chip > 0) {
             uint256 _dust = dust;
-            if (tab >= _dust && mul(lot, price) >= _dust) {
+            if (tab >= wmul(_dust, dog.chop(ilk)) && mul(lot, price) >= _dust) {
                 coin = add(_tip, wmul(tab, _chip));
                 vat.suck(vow, kpr, coin);
             }
@@ -373,14 +374,14 @@ contract Clipper {
                 slice = owe / price;        // slice' = owe' / price <= owe / price == slice <= lot
             } else if (owe < tab && slice < lot) {
                 // if slice == lot => auction completed => dust doesn't matter
-                uint256 _dust = dust;
-                if (tab - owe < _dust) {     // safe as owe < tab
-                    // if tab <= dust, buyers have to buy the whole thing
-                    require(tab > _dust, "Clipper/no-partial-purchase");
+                uint256 chost = wmul(dust, dog.chop());
+                if (tab - owe < chost) {     // safe as owe < tab
+                    // if tab / chop <= dust, buyers have to buy the whole thing
+                    require(tab > chost, "Clipper/no-partial-purchase");
                     // Adjust amount to pay
-                    owe = tab - _dust;       // owe' <= owe
+                    owe = tab - chost;       // owe' <= owe
                     // Adjust slice
-                    slice = owe / price;    // slice' = owe' / price < owe / price == slice < lot
+                    slice = owe / price;     // slice' = owe' / price < owe / price == slice < lot
                 }
             }
 

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -457,8 +457,8 @@ contract Clipper {
 
     // Public function to update the cached dust*chop value.
     function upchost() external {
-        (,,,, uint256 _dust) = VatLike(vat).ilks(_ilk);
-        chost = wmul(_dust, dog.chop(_ilk));
+        (,,,, uint256 _dust) = VatLike(vat).ilks(ilk);
+        chost = wmul(_dust, dog.chop(ilk));
     }
 
     // Cancel an auction during ES or via governance action.

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -137,8 +137,6 @@ contract Clipper {
         dog     = DogLike(dog_);
         ilk     = ilk_;
         buf     = RAY;
-        upchost(vat_, ilk_);
-
         wards[msg.sender] = 1;
         emit Rely(msg.sender);
     }
@@ -453,15 +451,10 @@ contract Clipper {
         done  = (sub(block.timestamp, tic) > tail || rdiv(price, top) < cusp);
     }
 
-    // Public function to update the cached dust value
+    // Public function to update the cached dust value.
     function upchost() external {
-        upchost(address(vat), ilk);
-    }
-
-    // The dog storage variable must be set to a valid Dog before calling this function.
-    function upchost(address _vat, bytes32 _ilk) internal {
-        (,,,, uint256 _dust) = VatLike(_vat).ilks(_ilk);
-        chost = wmul(_dust, dog.chop(_ilk));
+        (,,,, uint256 _dust) = VatLike(vat).ilks(ilk);
+        chost = wmul(_dust, dog.chop(ilk));
     }
 
     // Cancel an auction during ES or via governance action.

--- a/src/clip.sol
+++ b/src/clip.sol
@@ -365,12 +365,12 @@ contract Clipper {
                 slice = owe / price;        // slice' = owe' / price <= owe / price == slice <= lot
             } else if (owe < tab && slice < lot) {
                 // If slice == lot => auction completed => dust doesn't matter
-                uint256 chost_ = chost;
-                if (tab - owe < chost_) {    // safe as owe < tab
+                uint256 _chost = chost;
+                if (tab - owe < _chost) {    // safe as owe < tab
                     // If tab <= chost, buyers have to take the entire lot.
-                    require(tab > chost_, "Clipper/no-partial-purchase");
+                    require(tab > _chost, "Clipper/no-partial-purchase");
                     // Adjust amount to pay
-                    owe = tab - chost_;      // owe' <= owe
+                    owe = tab - _chost;      // owe' <= owe
                     // Adjust slice
                     slice = owe / price;     // slice' = owe' / price < owe / price == slice < lot
                 }

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -1094,7 +1094,7 @@ contract ClipperTest is DSTest {
 
         hevm.warp(now + 30);
 
-        (, uint256 _price, uint256 _lot, uint256 _tab) = clip.getStatus(1);
+        (, uint256 _price, uint256 _lot,) = clip.getStatus(1);
         Guy(bob).take({
             id:  1,
             amt: _lot,     // Buy the rest of the lot

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -380,6 +380,7 @@ contract ClipperTest is DSTest {
 
         // dust and chop filed previously so clip.chost will be set correctly
         clip = new Clipper(address(vat), address(spot), address(dog), ilk);
+        clip.upchost();
         clip.rely(address(dog));
 
         dog.file(ilk, "clip", address(clip));
@@ -749,6 +750,7 @@ contract ClipperTest is DSTest {
 
         bytes32 ilk2 = "silver";
         Clipper clip2 = new Clipper(address(vat), address(spot), address(dog), ilk2);
+        clip2.upchost();
         clip2.rely(address(dog));
 
         dog.file(ilk2, "clip", address(clip2));

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -516,7 +516,7 @@ contract ClipperTest is DSTest {
         pip.poke(bytes32(0));
 
         hevm.warp(startTime + 1801 seconds);
-        (bool needsRedo,) = clip.getStatus(1);
+        (bool needsRedo,,,) = clip.getStatus(1);
         assertTrue(needsRedo);
         clip.redo(1, address(this));
     }
@@ -973,7 +973,9 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
 
-        (, uint256 price) = clip.getStatus(1);
+        (, uint256 price,uint256 _lot, uint256 _tab) = clip.getStatus(1);
+        assertEq(_lot, lot);
+        assertEq(_tab, tab);
         assertEq(price, ray(5 ether));
 
         // Bid so owe (= (22 - 1wei) * 5 = 110 RAD - 1) < tab (= 110 RAD)
@@ -998,7 +1000,7 @@ contract ClipperTest is DSTest {
         assertEq(tab, rad(110 ether));
         assertEq(lot, 40 ether);
 
-        (, uint256 price) = clip.getStatus(1);
+        (, uint256 price,,) = clip.getStatus(1);
         assertEq(price, 2735783211953807380973706855); // 2.73 RAY
 
         // Bid so owe (= (22 - 1wei) * 5 = 110 RAD - 1) < tab (= 110 RAD)
@@ -1020,7 +1022,7 @@ contract ClipperTest is DSTest {
     }
 
     function test_take_bid_fails_no_partial_allowed() public takeSetup {
-        (, uint256 price) = clip.getStatus(1);
+        (, uint256 price,,) = clip.getStatus(1);
         assertEq(price, ray(5 ether));
 
         clip.take({
@@ -1084,11 +1086,11 @@ contract ClipperTest is DSTest {
 
         hevm.warp(now + 30);
 
-        (, uint256 price) = clip.getStatus(1);
+        (, uint256 _price, uint256 _lot, uint256 _tab) = clip.getStatus(1);
         Guy(bob).take({
             id:  1,
-            amt: 30 ether,     // Buy the rest of the lot
-            max: ray(4 ether), // 5 * 0.99 ** 30 = 3.698501866941401 RAY => max > price
+            amt: _lot,     // Buy the rest of the lot
+            max: ray(_price), // 5 * 0.99 ** 30 = 3.698501866941401 RAY => max > price
             who: address(bob),
             data: ""
         });
@@ -1102,9 +1104,9 @@ contract ClipperTest is DSTest {
         assertEq(uint256(tic), 0);
         assertEq(top, 0);
 
-        uint256 expectedGem = (RAY * 60 ether) / price;  // tab / price
-        assertEq(vat.gem(ilk, bob), expectedGem);        // Didn't take whole lot
-        assertEq(vat.dai(bob), rad(940 ether));          // Paid rest of tab (60)
+        uint256 expectedGem = (RAY * 60 ether) / _price;  // tab / price
+        assertEq(vat.gem(ilk, bob), expectedGem);         // Didn't take whole lot
+        assertEq(vat.dai(bob), rad(940 ether));           // Paid rest of tab (60)
 
         uint256 lotReturn = 30 ether - expectedGem;         // lot - loaf.tab / max = 15
         assertEq(vat.gem(ilk, me), 960 ether + lotReturn);  // Collateral returned (10 WAD)
@@ -1141,11 +1143,11 @@ contract ClipperTest is DSTest {
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
 
         hevm.warp(startTime + 3600 seconds);
-        (bool needsRedo,) = clip.getStatus(1);
+        (bool needsRedo,,,) = clip.getStatus(1);
         assertTrue(!needsRedo);
         assertTrue(!try_redo(1, address(this)));
         hevm.warp(startTime + 3601 seconds);
-        (needsRedo,) = clip.getStatus(1);
+        (needsRedo,,,) = clip.getStatus(1);
         assertTrue(needsRedo);
         assertTrue(try_redo(1, address(this)));
 
@@ -1164,11 +1166,11 @@ contract ClipperTest is DSTest {
         assertEq(topBefore, ray(5 ether)); // $4 spot + 25% buffer = $5 (wasn't affected by poke)
 
         hevm.warp(startTime + 1800 seconds);
-        (bool needsRedo,) = clip.getStatus(1);
+        (bool needsRedo,,,) = clip.getStatus(1);
         assertTrue(!needsRedo);
         assertTrue(!try_redo(1, address(this)));
         hevm.warp(startTime + 1801 seconds);
-        (needsRedo,) = clip.getStatus(1);
+        (needsRedo,,,) = clip.getStatus(1);
         assertTrue(needsRedo);
         assertTrue(try_redo(1, address(this)));
 
@@ -1334,7 +1336,7 @@ contract ClipperTest is DSTest {
 
         hevm.warp(now + 100); // Reducing the price
 
-        (, uint256 price) = clip.getStatus(1);
+        (, uint256 price,,) = clip.getStatus(1);
         assertEq(price, 1830161706366147524653080130); // 1.83 RAY
 
         clip.take({


### PR DESCRIPTION
We corrected how `dust` was handled in the Dog, but not the Clipper, in the course of the audits. This PR shows what fully making this consistent looks like. It is maybe too late to put it in (as it's IMO a low severity issue, just an inconsistency that could occasionally lead to dusty amounts of collateral left by partial `takes`, which can happen anyway e.g. if a dusty Vault is liquidated), but I thought everyone should at least understand why the current code is inconsistent. If we launch with that inconsistency, it can potentially be corrected in Liq 2.1, which also gives us more time to refactor into a more gas-efficient format (a good argument against this change is that the small inconsistency is acceptable in order to reduce gas costs).