### PR TITLE
Change vow to use a proxy

### DIFF
--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -8,7 +8,7 @@ import "ds-value/value.sol";
 
 import {Vat}     from "../vat.sol";
 import {Spotter} from "../spot.sol";
-import {Vow}     from "../vow.sol";
+import {Vow, VowProxy}    from "../vow.sol";
 import {GemJoin, DaiJoin} from "../join.sol";
 
 import {Clipper} from "../clip.sol";
@@ -339,7 +339,10 @@ contract ClipperTest is DSTest {
         spot = new Spotter(address(vat));
         vat.rely(address(spot));
 
-        vow = new Vow(address(vat), address(0), address(0));
+        vow = Vow(address(new VowProxy()));
+        address vowImp = address(new Vow(address(vat)));
+        VowProxy(address(vow)).setImplementation(vowImp);
+        vow.init();
         gold = new DSToken("GLD");
         goldJoin = new GemJoin(address(vat), ilk, address(gold));
         vat.rely(address(goldJoin));
@@ -357,7 +360,7 @@ contract ClipperTest is DSTest {
         dog = new Dog(address(vat));
         dog.file("vow", address(vow));
         vat.rely(address(dog));
-        vow.rely(address(dog));
+        VowProxy(address(vow)).rely(address(dog));
 
         vat.init(ilk);
 

--- a/src/test/clip.t.sol
+++ b/src/test/clip.t.sol
@@ -342,7 +342,6 @@ contract ClipperTest is DSTest {
         vow = Vow(address(new VowProxy()));
         address vowImp = address(new Vow(address(vat)));
         VowProxy(address(vow)).setImplementation(vowImp);
-        vow.init();
         gold = new DSToken("GLD");
         goldJoin = new GemJoin(address(vat), ilk, address(gold));
         vat.rely(address(goldJoin));

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -211,7 +211,6 @@ contract EndTest is DSTest {
         vow = Vow(address(new VowProxy()));
         address vowImp = address(new Vow(address(vat)));
         VowProxy(address(vow)).setImplementation(vowImp);
-        vow.init();
         vow.file("flapper", address(flap));
         vow.file("flopper", address(flop));
 

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -27,7 +27,7 @@ import "ds-value/value.sol";
 import {Vat}  from '../vat.sol';
 import {Cat}  from '../cat.sol';
 import {Dog}  from '../dog.sol';
-import {Vow}  from '../vow.sol';
+import {Vow, VowProxy}  from '../vow.sol';
 import {Pot}  from '../pot.sol';
 import {Flipper} from '../flip.sol';
 import {Clipper} from '../clip.sol';
@@ -208,7 +208,12 @@ contract EndTest is DSTest {
         flop = new Flopper(address(vat), address(gov));
         gov.setOwner(address(flop));
 
-        vow = new Vow(address(vat), address(flap), address(flop));
+        vow = Vow(address(new VowProxy()));
+        address vowImp = address(new Vow(address(vat)));
+        VowProxy(address(vow)).setImplementation(vowImp);
+        vow.init();
+        vow.file("flapper", address(flap));
+        vow.file("flopper", address(flop));
 
         pot = new Pot(address(vat));
         vat.rely(address(pot));
@@ -217,12 +222,12 @@ contract EndTest is DSTest {
         cat = new Cat(address(vat));
         cat.file("vow", address(vow));
         vat.rely(address(cat));
-        vow.rely(address(cat));
+        VowProxy(address(vow)).rely(address(cat));
 
         dog = new Dog(address(vat));
         dog.file("vow", address(vow));
         vat.rely(address(dog));
-        vow.rely(address(dog));
+        VowProxy(address(vow)).rely(address(dog));
 
         spot = new Spotter(address(vat));
         vat.file("Line",         rad(1_000_000 ether));
@@ -237,7 +242,7 @@ contract EndTest is DSTest {
         end.file("spot", address(spot));
         end.file("wait", 1 hours);
         vat.rely(address(end));
-        vow.rely(address(end));
+        VowProxy(address(vow)).rely(address(end));
         spot.rely(address(end));
         pot.rely(address(end));
         cat.rely(address(end));

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -487,7 +487,6 @@ contract BiteTest is DSTest {
         vow = TestVow(address(new VowProxy()));
         address vowImp = address(new TestVow(address(vat)));
         VowProxy(address(vow)).setImplementation(vowImp);
-        vow.init();
         vow.file("flapper", address(flap));
         vow.file("flopper", address(flop));
         flap.rely(address(vow));

--- a/src/test/vat.t.sol
+++ b/src/test/vat.t.sol
@@ -7,7 +7,7 @@ import "ds-token/token.sol";
 
 import {Vat} from '../vat.sol';
 import {Cat} from '../cat.sol';
-import {Vow} from '../vow.sol';
+import {Vow, VowProxy} from '../vow.sol';
 import {Jug} from '../jug.sol';
 import {GemJoin, DaiJoin} from '../join.sol';
 
@@ -30,8 +30,8 @@ contract TestVat is Vat {
 }
 
 contract TestVow is Vow {
-    constructor(address vat, address flapper, address flopper)
-        public Vow(vat, flapper, flopper) {}
+    constructor(address vat)
+        public Vow(vat) {}
     // Total deficit
     function Awe() public view returns (uint) {
         return vat.sin(address(this));
@@ -484,7 +484,12 @@ contract BiteTest is DSTest {
         flap = new Flapper(address(vat), address(gov));
         flop = new Flopper(address(vat), address(gov));
 
-        vow = new TestVow(address(vat), address(flap), address(flop));
+        vow = TestVow(address(new VowProxy()));
+        address vowImp = address(new TestVow(address(vat)));
+        VowProxy(address(vow)).setImplementation(vowImp);
+        vow.init();
+        vow.file("flapper", address(flap));
+        vow.file("flopper", address(flop));
         flap.rely(address(vow));
         flop.rely(address(vow));
 
@@ -497,7 +502,7 @@ contract BiteTest is DSTest {
         cat.file("vow", address(vow));
         cat.file("box", rad((10 ether) * MLN));
         vat.rely(address(cat));
-        vow.rely(address(cat));
+        VowProxy(address(vow)).rely(address(cat));
 
         gold = new DSToken("GEM");
         gold.mint(1000 ether);

--- a/src/test/vow.t.sol
+++ b/src/test/vow.t.sol
@@ -42,7 +42,6 @@ contract VowTest is DSTest {
         vow = Vow(address(new VowProxy()));
         address vowImp = address(new Vow(address(vat)));
         VowProxy(address(vow)).setImplementation(vowImp);
-        vow.init();
         vow.file("flapper", address(flap));
         vow.file("flopper", address(flop));
         flap.rely(address(vow));

--- a/src/test/vow.t.sol
+++ b/src/test/vow.t.sol
@@ -7,7 +7,7 @@ import "ds-test/test.sol";
 import {Flopper as Flop} from './flop.t.sol';
 import {Flapper as Flap} from './flap.t.sol';
 import {TestVat as  Vat} from './vat.t.sol';
-import {Vow}     from '../vow.sol';
+import {Vow, VowProxy}   from '../vow.sol';
 
 interface Hevm {
     function warp(uint256) external;
@@ -39,7 +39,12 @@ contract VowTest is DSTest {
         flop = new Flop(address(vat), address(gov));
         flap = new Flap(address(vat), address(gov));
 
-        vow = new Vow(address(vat), address(flap), address(flop));
+        vow = Vow(address(new VowProxy()));
+        address vowImp = address(new Vow(address(vat)));
+        VowProxy(address(vow)).setImplementation(vowImp);
+        vow.init();
+        vow.file("flapper", address(flap));
+        vow.file("flopper", address(flop));
         flap.rely(address(vow));
         flop.rely(address(vow));
 

--- a/src/vow.sol
+++ b/src/vow.sol
@@ -130,11 +130,6 @@ contract Vow {
         vat = VatLike(vat_);
     }
 
-    // Needs to be called outside of constructor via proxy
-    function init() external {
-        vat.hope(address(flapper));
-    }
-
     // --- Math ---
     function add(uint x, uint y) internal pure returns (uint z) {
         require((z = x + y) >= x);


### PR DESCRIPTION
Vow will need to be replaced when we update the flap/flop mechanism to dutch auctions. During that replacement I recommend we switch to using an upgradable proxy design so that `vow` address will remain constant moving forward. Upgradable contracts is in general an anti-pattern, but for this specific instance it makes a lot of sense.`vow` is one of the most commonly referenced contracts only behind `vat`, `dai` and `daiJoin`. In almost all instances of referencing `vow` the contract is either pushing revenue to the surplus buffer or pulling debt from it. Both of these operations require no knowledge of the `vow` interface. It is simply an address.

By making the `vow` address constant we can make the variable immutable in all referencing contracts which will not only save gas, it will also make dealing with `vow` upgrades no longer a concern. Current solutions involve either redeploying the contract (https://github.com/makerdao/dss-flash/blob/master/src/flash.sol#L59), filing a new `vow` (https://github.com/makerdao/dss-wormhole/blob/master/src/WormholeJoin.sol#L109) or doing a dynamic lookup from the chainlog (https://github.com/makerdao/dss-direct-deposit/blob/master/src/DssDirectDepositAaveDai.sol#L348). All of these solutions are sub-par imo. By using an upgradable proxy design we can change the vow without having to iterate over the many many locations it is referenced.

Furthermore with the `file(...)` solution it may be the case that eventually there isn't enough room in the block to synchronously update all the locations `vow` is referenced. I would like to get ahead of this problem before it bites us in the ass in a few years.

The proposed changes are designed to be minimal, so the first step is to just move over to the proxy design with no other changes. It probably makes sense to add events as well, so if people want to proceed I'll add those. Next step can be to upgrade the `flop` and `flap` auctions.