### PR TITLE
add test of lid alteration during auction

### DIFF
--- a/src/test/flap.t.sol
+++ b/src/test/flap.t.sol
@@ -208,4 +208,24 @@ contract FlapTest is DSTest {
         flap.deal(id2);
         assertEq(flap.fill(), 300 ether);
     }
+    function test_mod_lid_in_flight() public {
+        uint256 id = flap.kick({ lot: 400 ether
+                  , bid: 0
+                  });
+        assertEq(flap.fill(), 400 ether);
+
+        // Reduce lid while auction is active
+        flap.file("lid", 300 ether);
+
+        Guy(ali).tend(id, 400 ether, 1 ether);
+        assertEq(flap.fill(), 300 ether);
+        hevm.warp(block.timestamp + 30 days);
+        flap.deal(id);
+        assertEq(flap.fill(), 0);
+        flap.kick({ lot: 300 ether
+                  , bid: 0
+                  });
+        assertEq(flap.fill(), 300 ether);
+    }
+
 }


### PR DESCRIPTION
Adds a test of reducing the `lid` while the auction is active to assert we don't get into a stuck state.