### PR TITLE
Set only after cage, and force cage on End.cage

### DIFF
--- a/src/cure.sol
+++ b/src/cure.sol
@@ -41,11 +41,6 @@ contract Cure {
         _;
     }
 
-    modifier isLive {
-        require(live == 1, "Cure/not-live");
-        _;
-    }
-
     // --- Internal ---
     function _add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x + y) >= x, "Cure/add-overflow");
@@ -69,25 +64,27 @@ contract Cure {
         return sources;
     }
 
-    function rely(address usr) external auth isLive {
+    function rely(address usr) external auth {
+        require(live == 1, "Cure/not-live");
         wards[usr] = 1;
         emit Rely(usr);
     }
 
-    function deny(address usr) external auth isLive {
+    function deny(address usr) external auth {
+        require(live == 1, "Cure/not-live");
         wards[usr] = 0;
         emit Deny(usr);
     }
 
-    function addSource(address src) external auth isLive {
+    function addSource(address src) external auth {
+        require(live == 1, "Cure/not-live");
         require(pos[src] == 0, "Cure/already-existing-source");
         sources.push(src);
         pos[src] = sources.length;
-        uint256 amt_ = amt[src] = SourceLike(src).cure();
-        total = _add(total, amt_);
     }
 
-    function delSource(address src) external auth isLive {
+    function delSource(address src) external auth {
+        require(live == 1, "Cure/not-live");
         uint256 pos_ = pos[src];
         require(pos_ > 0, "Cure/non-existing-source");
         uint256 last = sources.length;
@@ -97,17 +94,18 @@ contract Cure {
             pos[move] = pos_;
         }
         sources.pop();
-        total = _sub(total, amt[src]);
         delete pos[src];
         delete amt[src];
     }
 
-    function cage() external auth isLive {
+    function cage() external auth {
+        require(live == 1, "Cure/not-live");
         live = 0;
         emit Cage();
     }
 
-    function reset(address src) external {
+    function set(address src) external {
+        require(live == 0, "Cure/still-live");
         require(pos[src] > 0, "Cure/non-existing-source");
         uint256 oldAmt_ = amt[src];
         uint256 newAmt_ = amt[src] = SourceLike(src).cure();

--- a/src/end.sol
+++ b/src/end.sol
@@ -111,6 +111,7 @@ interface SpotLike {
 
 interface CureLike {
     function total() external view returns (uint256);
+    function cage() external;
 }
 
 /*
@@ -339,6 +340,7 @@ contract End {
         vow.cage();
         spot.cage();
         pot.cage();
+        cure.cage();
         emit Cage();
     }
 

--- a/src/test/cure.t.sol
+++ b/src/test/cure.t.sol
@@ -138,58 +138,81 @@ contract CureTest is DSTest {
         cure.delSource(addr2);
     }
 
-    function testCure() public {
-        cure.addSource(address(new SourceMock(15_000)));
-        assertEq(cure.total(), 15_000);
-        cure.addSource(address(new SourceMock(30_000)));
-        assertEq(cure.total(), 45_000);
-        cure.addSource(address(new SourceMock(50_000)));
-        assertEq(cure.total(), 95_000);
-    }
-
-    function testReset() public {
-        SourceMock source1 = new SourceMock(2_000);
-        SourceMock source2 = new SourceMock(3_000);
-        cure.addSource(address(source1));
-        cure.addSource(address(source2));
-        assertEq(cure.total(), 5_000);
-        source1.update(4_000);
-        assertEq(cure.total(), 5_000);
-        cure.reset(address(source1));
-        assertEq(cure.total(), 7_000);
-        source2.update(6_000);
-        assertEq(cure.total(), 7_000);
-        cure.reset(address(source2));
-        assertEq(cure.total(), 10_000);
-    }
-
-    function testResetNoChange() public {
-        SourceMock source = new SourceMock(2_000);
-        cure.addSource(address(source));
-        assertEq(cure.total(), 2_000);
-        cure.reset(address(source));
-        assertEq(cure.total(), 2_000);
-    }
-
-    function testFailResetNotAdded() public {
-        SourceMock source = new SourceMock(2_000);
-        cure.reset(address(source));
-    }
-
     function testCage() public {
         assertEq(cure.live(), 1);
         cure.cage();
         assertEq(cure.live(), 0);
     }
 
-    function testResetAfterCage() public {
-        SourceMock source = new SourceMock(2_000);
-        cure.addSource(address(source));
-        assertEq(cure.total(), 2_000);
+    function testCure() public {
+        address source1 = address(new SourceMock(15_000));
+        address source2 = address(new SourceMock(30_000));
+        address source3 = address(new SourceMock(50_000));
+        cure.addSource(source1);
+        cure.addSource(source2);
+        cure.addSource(source3);
+
         cure.cage();
-        source.update(1_000);
-        cure.reset(address(source));
-        assertEq(cure.total(), 1_000);
+
+        cure.set(source1);
+        assertEq(cure.total(), 15_000);
+        cure.set(source2);
+        assertEq(cure.total(), 45_000);
+        cure.set(source3);
+        assertEq(cure.total(), 95_000);
+    }
+
+    function testSetMultipleTimes() public {
+        address source1 = address(new SourceMock(2_000));
+        address source2 = address(new SourceMock(3_000));
+        cure.addSource(source1);
+        cure.addSource(source2);
+
+        cure.cage();
+
+        cure.set(source1);
+        cure.set(source2);
+        assertEq(cure.total(), 5_000);
+
+        SourceMock(source1).update(4_000);
+        assertEq(cure.total(), 5_000);
+
+        cure.set(source1);
+        assertEq(cure.total(), 7_000);
+
+        SourceMock(source2).update(6_000);
+        assertEq(cure.total(), 7_000);
+
+        cure.set(source2);
+        assertEq(cure.total(), 10_000);
+    }
+
+    function testSetNoChange() public {
+        address source = address(new SourceMock(2_000));
+        cure.addSource(source);
+
+        cure.cage();
+
+        cure.set(source);
+        assertEq(cure.total(), 2_000);
+
+        cure.set(source);
+        assertEq(cure.total(), 2_000);
+    }
+
+    function testFailSetNotCaged() public {
+        address source = address(new SourceMock(2_000));
+        cure.addSource(source);
+
+        cure.set(source);
+    }
+
+    function testFailSetNotAdded() public {
+        address source = address(new SourceMock(2_000));
+
+        cure.cage();
+
+        cure.set(source);
     }
 
     function testFailCagedRely() public {
@@ -204,14 +227,14 @@ contract CureTest is DSTest {
 
     function testFailCagedAddSource() public {
         cure.cage();
-        address addr = address(new SourceMock(0));
-        cure.addSource(addr);
+        address source = address(new SourceMock(0));
+        cure.addSource(source);
     }
 
     function testFailCagedDelSource() public {
-        address addr = address(new SourceMock(0));
-        cure.addSource(addr);
+        address source = address(new SourceMock(0));
+        cure.addSource(source);
         cure.cage();
-        cure.delSource(addr);
+        cure.delSource(source);
     }
 }

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -248,6 +248,7 @@ contract EndTest is DSTest {
         pot.rely(address(end));
         cat.rely(address(end));
         dog.rely(address(end));
+        cure.rely(address(end));
         flap.rely(address(vow));
         flop.rely(address(vow));
     }


### PR DESCRIPTION
This PR makes the `cure` implementation closer to what you guys have been discussing. Do you think this way is a bit better?
It would be missing the control that every source is set after `cage` (which I'm still not sure if really needed)