### PR TITLE
Bugfix drip() in Pot

### DIFF
--- a/src/pot.sol
+++ b/src/pot.sol
@@ -152,7 +152,7 @@ contract Pot {
 
     // --- Savings Dai Management ---
     function join(uint wad) external {
-        require(now == rho, "Pot/rho-not-updated");
+        require(now >= rho, "Pot/rho-not-updated");
         pie[msg.sender] = add(pie[msg.sender], wad);
         Pie             = add(Pie,             wad);
         vat.move(msg.sender, address(this), mul(chi, wad));


### PR DESCRIPTION
Small bug fix in pot.sol in the drip() function where the current time can never be equal to rho.