### PR TITLE
add failing function call example

### DIFF
--- a/src/end.sol
+++ b/src/end.sol
@@ -101,6 +101,7 @@ interface PipLike {
 }
 
 interface SpotLike {
+    function read(bytes32) external view returns(uint256);
     function par() external view returns (uint256);
     function ilks(bytes32) external view returns (
         PipLike pip,
@@ -342,7 +343,7 @@ contract End {
         (Art[ilk],,,,) = vat.ilks(ilk);
         (PipLike pip,) = spot.ilks(ilk);
         // par is a ray, pip returns a wad
-        tag[ilk] = wdiv(spot.par(), uint256(pip.read()));
+        tag[ilk] = wdiv(spot.par(), uint256(spot.read(ilk)));
         emit Cage(ilk);
     }
 

--- a/src/spot.sol
+++ b/src/spot.sol
@@ -27,6 +27,7 @@ interface VatLike {
 
 interface PipLike {
     function peek() external returns (bytes32, bool);
+    function read() external view returns (bytes32);
 }
 
 contract Spotter {
@@ -58,6 +59,8 @@ contract Spotter {
       bytes32 val,  // [wad]
       uint256 spot  // [ray]
     );
+
+    event Read(bytes32 ilk, uint256 val);
 
     // --- Init ---
     constructor(address vat_) public {
@@ -92,6 +95,11 @@ contract Spotter {
         require(live == 1, "Spotter/not-live");
         if (what == "mat") ilks[ilk].mat = data;
         else revert("Spotter/file-unrecognized-param");
+    }
+
+    function read(bytes32 ilk) external returns(uint256 val) {
+        val = uint256(ilks[ilk].pip.read());
+        emit Read(ilk, val);
     }
 
     // --- Update value ---


### PR DESCRIPTION
Example of a reverting function call that does not provide additional information for https://github.com/foundry-rs/foundry/issues/1387#issuecomment-1107514233

run with `forge test --match-contract="EndTest" -vvv`