### PR TITLE
Revert on end.cage(ilk) if there is not Art for that ilk

### DIFF
--- a/src/end.sol
+++ b/src/end.sol
@@ -347,7 +347,9 @@ contract End {
     function cage(bytes32 ilk) external {
         require(live == 0, "End/still-live");
         require(tag[ilk] == 0, "End/tag-ilk-already-defined");
-        (Art[ilk],,,,) = vat.ilks(ilk);
+        (uint256 Art_,,,,) = vat.ilks(ilk);
+        require(Art_ > 0, "End/Art-is-zero");
+        Art[ilk] = Art_;
         (PipLike pip,) = spot.ilks(ilk);
         // par is a ray, pip returns a wad
         tag[ilk] = wdiv(spot.par(), uint256(pip.read()));
@@ -355,8 +357,6 @@ contract End {
     }
 
     function snip(bytes32 ilk, uint256 id) external {
-        require(tag[ilk] != 0, "End/tag-ilk-not-defined");
-
         (address _clip,,,) = dog.ilks(ilk);
         ClipLike clip = ClipLike(_clip);
         (, uint256 rate,,,) = vat.ilks(ilk);
@@ -373,8 +373,6 @@ contract End {
     }
 
     function skip(bytes32 ilk, uint256 id) external {
-        require(tag[ilk] != 0, "End/tag-ilk-not-defined");
-
         (address _flip,,) = cat.ilks(ilk);
         FlipLike flip = FlipLike(_flip);
         (, uint256 rate,,,) = vat.ilks(ilk);

--- a/src/test/end.t.sol
+++ b/src/test/end.t.sol
@@ -344,6 +344,17 @@ contract EndTest is DSTest {
         assertEq(balanceOf("gold", address(gold.gemA)), 0);
     }
 
+    // -- Scenario where there is not debt for an ilk
+    // -- which needs to lead to a revert
+    function testFail_cage_no_Art() public {
+        Ilk memory gold = init_collateral("gold");
+
+        // collateral price is 5
+        gold.pip.poke(bytes32(5 * WAD));
+        end.cage();
+        end.cage("gold");
+    }
+
     // -- Scenario where there is one over-collateralised and one
     // -- under-collateralised CDP, and no Vow deficit or surplus
     function test_cage_undercollateralised() public {
@@ -462,9 +473,9 @@ contract EndTest is DSTest {
         // collateral price is 5
         gold.pip.poke(bytes32(5 * WAD));
         end.cage();
-        end.cage("gold");
 
         end.skip("gold", auction);
+        end.cage("gold");
         assertEq(dai(address(this)), 1 ether);       // bid refunded
         vat.move(address(this), urn1, rad(1 ether)); // return 1 dai to ali
 
@@ -565,8 +576,6 @@ contract EndTest is DSTest {
         gold.pip.poke(bytes32(5 * WAD));
         spot.poke("gold");
         end.cage();
-        end.cage("gold");
-        assertEq(end.tag("gold"), ray(0.2 ether)); // par / price = collateral per DAI
 
         assertEq(vat.gem("gold", address(gold.clip)), lot1); // From grab in dog.bark()
         assertEq(vat.sin(address(vow)),        art1 * rate); // From grab in dog.bark()
@@ -604,6 +613,9 @@ contract EndTest is DSTest {
         (uint ink3, uint art3) = vat.urns("gold", urn1);    // CDP after snip
         assertEq(ink3, 10 ether);                           // All collateral returned to CDP
         assertEq(art3, tab1 / rate);                        // Tab amount of normalized debt transferred back into CDP
+
+        end.cage("gold");
+        assertEq(end.tag("gold"), ray(0.2 ether)); // par / price = collateral per DAI
     }
 
     // -- Scenario where there is one over-collateralised CDP


### PR DESCRIPTION
So the change didn't result as simple as it seemed.
Adding the revert condition is a bit problematic for `skip` and `snip` if all the debt of that ilk is in running auctions (that was exactly the case of the tests).

Without a `tag` the auctions can't be yanked. This case is very improbably in practice as for a specific `ilk` would be super rare there isn't at least one open CDP which passes the new `Art` `require` condition.
However if that happened, it would mean that auctions can't be yanked nor collateral caged leaving it like in a trap (well still can finish through the normal auction path).

So the correct thing to do would be removing the `require` of `tag > 0` in `skip` and `snip`. I still need to do a better review but seems wouldn't be a problem. If `cage(ilk)` is called after some `skip` or `snip` nothing bad should happen as the `Art` itself will be overwritten taking into account again the auction that was previously yanked. And `tag` doesn't really seem to be necessary to run `skip` or `snip`.

I'd like to hear some opinions thought before thinking on deeper test cases. Do we feel we can continue this path or should we reconsider it?